### PR TITLE
sim-cli: extract shared runtime skill; pilot 3 driver skills

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,10 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What is this directory?
 
-`sim-skills/` is a collection of **per-solver agent skills** for the [`sim`](../sim-cli/) simulation runtime. Each subdirectory (`abaqus/`, `ansa/`, `cfx/`, `comsol/`, `flotherm/`, `fluent/`, `lsdyna/`, `mapdl/`, `matlab/`, `mechanical/`, `openfoam/`, `pybamm/`, `starccm/`, `workbench/`) is **one skill** in the Anthropic skill format:
+`sim-skills/` is a collection of agent skills for the [`sim`](../sim-cli/) simulation runtime. It contains two kinds of skill:
+
+- **[`sim-cli/`](sim-cli/SKILL.md)** — the shared runtime-contract skill. Owns session lifecycle, command surface, input classification, Step-0 version awareness, acceptance, and escalation. Load alongside any driver skill.
+- **Per-solver skills** (`abaqus/`, `ansa/`, `cfx/`, `comsol/`, `flotherm/`, `fluent/`, `lsdyna/`, `mapdl/`, `matlab/`, `mechanical/`, `openfoam/`, `pybamm/`, `starccm/`, `workbench/`, …). Each is one Anthropic-format skill that layers solver-specific rules on top of the shared contract.
 
 ```
 <solver>/
@@ -18,13 +21,19 @@ The skills tell an LLM agent **how to drive a given solver through `sim`** — i
 
 When a task involves any supported solver:
 
-1. Identify the solver from the user's request
-2. Read `<solver>/SKILL.md` — its YAML `description` field describes exactly when it applies, and the body has the required protocol
-3. Follow the protocol step by step (input validation → connect → execute → verify → report)
-4. Reach for supporting files when SKILL.md instructs: `reference/` for patterns and templates, `workflows/` for end-to-end examples, `snippets/` for ready-made `sim exec` payloads, `skill_tests/` for acceptance test cases
-5. **Never invent solver-specific defaults for Category A (physical-decision) inputs** — ask the user
+1. **Load [`sim-cli/SKILL.md`](sim-cli/SKILL.md)** for the shared runtime contract.
+2. Identify the solver from the user's request.
+3. Read `<solver>/SKILL.md` — its YAML `description` field describes exactly when it applies, and the body has the solver-specific overlay on top of the sim-cli contract.
+4. Follow the protocol step by step (input validation → connect / run → execute → verify → report).
+5. Reach for supporting files when SKILL.md instructs: `reference/` for patterns and templates, `workflows/` for end-to-end examples, `snippets/` for ready-made `sim exec` payloads, `skill_tests/` for acceptance test cases.
+6. **Never invent solver-specific defaults for Category A (physical-decision) inputs** — ask the user.
 
-## The 36 skills
+## Skills
+
+The shared-contract skill ([`sim-cli/`](sim-cli/SKILL.md)) is listed
+above. The per-solver skills follow.
+
+
 
 | Directory | Skill name | Use when |
 |---|---|---|
@@ -70,60 +79,22 @@ When a task involves any supported solver:
 
 ## Cross-skill conventions
 
-These conventions apply across all 38 skills. Each individual SKILL.md may add its own constraints on top.
+The shared runtime contract — input classification (Category A/B/C),
+acceptance semantics, Step-0 version probe, escalation triggers,
+command surface, session lifecycle — lives in the **[`sim-cli/`](sim-cli/SKILL.md)** skill.
 
-### Input classification (used in every skill's "Required protocol" Step 1)
+That skill is the source of truth for every rule that applies to more
+than one driver. Load it alongside any driver skill. Per-driver
+SKILL.mds own only the solver-specific layer.
 
-- **Category A — Physical decision inputs:** must ask the user if absent. These define what the simulation physically represents (geometry, materials, boundary conditions, acceptance criteria). User pressure to "just use defaults" does NOT override this.
-- **Category B — Operational inputs:** may default, must disclose. These affect runtime/performance only (processors, ui_mode, smoke-test iteration counts).
-- **Category C — File-derivable:** infer from the actual provided files via a diagnostic snippet, not from reference examples. Confirm with the user if critical.
+Quick pointers into the shared skill:
 
-### Acceptance criteria are required inputs
-
-For every skill: `exit_code == 0` ALONE does **not** satisfy acceptance. Always validate against an outcome-based criterion ("outlet temperature in 28–35°C", "150 iterations completed", "min mesh quality > 0.2"). Phrases like "just run it" / "跑完就好" describe an operation, not an outcome — treat them as a missing input and ask.
-
-### Reference example values are NOT defaults
-
-Values in any `reference/.../examples/` directory describe a specific published test case. They are **not** silently applicable to a different user's task. You may *offer* them ("the mixing_elbow example uses 0.4 m/s — would you like to use those values?") but must wait for explicit confirmation before adopting them as Category A inputs.
-
-### Runtime version awareness (Step 0 of every skill)
-
-**Mandatory.** The first thing every skill protocol does after `sim connect` succeeds is:
-
-```bash
-sim --host <ip> inspect session.versions
-```
-
-This returns:
-
-```json
-{
-  "sdk":     {"name": "ansys-fluent-core", "version": "0.38.1"},
-  "solver":  {"name": "fluent",            "version": "25.2"},
-  "profile": "pyfluent_0_38_modern",
-  "skill_revision": "v2",
-  "env_path": "/.../.sim/envs/fluent-pyfluent-0-38"
-}
-```
-
-The agent **must** use the returned `profile` (or `skill_revision`) to choose which subfolder to load:
-
-- **Snippets:** read only from `<skill>/snippets/<profile>/*.py` and `<skill>/snippets/common/*.py`. Never load a snippet from a different profile folder.
-- **Reference docs:** anything in `<skill>/reference/<profile>/` overrides anything in `<skill>/reference/common/` for that profile.
-- **Workflows:** same profile-folder rule as snippets.
-
-If `profile` is empty, unknown, or marked deprecated in the driver's `compatibility.yaml`, **stop and surface the version table to the user**. Do not guess. The contract for this whole mechanism is in [`sim-cli/docs/architecture/version-compat.md`](https://github.com/svd-ai-lab/sim-cli/blob/main/docs/architecture/version-compat.md).
-
-Why this matters: a snippet written for PyFluent 0.38 (uses `.general.material`) silently produces `AttributeError` on PyFluent 0.37 (which expects `.material` directly). Without Step 0 the agent has no way to tell which dialect it should write — it would have to guess from the SDK version, which is exactly the bug Step 0 fixes.
-
-### When to stop and escalate
-
-Across all skills, stop and report (don't silently retry) when:
-- The solver / driver is unavailable or fails to launch
-- The runtime profile is empty, unknown, or deprecated (see "Runtime version awareness" above)
-- A snippet returns non-zero exit / `ok=false` / raises an exception
-- Session state is inconsistent with expectations after a step
-- The acceptance checklist cannot be satisfied
+- [`sim-cli/reference/input_classification.md`](sim-cli/reference/input_classification.md) — Category A / B / C
+- [`sim-cli/reference/acceptance.md`](sim-cli/reference/acceptance.md) — `exit_code == 0` is not acceptance
+- [`sim-cli/reference/version_awareness.md`](sim-cli/reference/version_awareness.md) — mandatory Step-0 `sim inspect session.versions` probe
+- [`sim-cli/reference/lifecycle.md`](sim-cli/reference/lifecycle.md) — persistent and one-shot control patterns
+- [`sim-cli/reference/command_surface.md`](sim-cli/reference/command_surface.md) — canonical `sim serve | run | connect | exec | inspect | disconnect`
+- [`sim-cli/reference/escalation.md`](sim-cli/reference/escalation.md) — stop-and-report triggers
 
 ## Runtime dependency
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Every skill lives in its own top-level folder. The grid is **open and growing** 
 
 | Skill | Domain | Execution model | Phase | What it's for |
 |---|---|---|---|---|
+| [**sim-cli**](sim-cli/SKILL.md) | *Shared contract* | Both (persistent + one-shot) | Working ✅ | The runtime contract every driver skill depends on — session lifecycle, command surface, input classification, Step-0 version probe, acceptance, escalation. **Load alongside any driver skill below.** |
 | [**fluent-sim**](fluent/SKILL.md) | CFD | Persistent meshing / solver session (PyFluent 0.38) | v0 ✅ | Incremental `sim exec` snippets or single-file workflows against a live Fluent session |
 | [**comsol-sim**](comsol/SKILL.md) | Multiphysics | Persistent JPype Java API session | Working ✅ | Long multiphysics runs with optional human GUI oversight |
 | [**openfoam-sim**](openfoam/SKILL.md) | CFD (OSS) | Remote `sim serve` on Linux via SSH tunnel | Working ✅ | Meshing, MPI parallel, classifier-based pass/fail on OpenFOAM v2206 |
@@ -117,16 +118,18 @@ The human workflow is even simpler: an engineer points the LLM at `sim-skills`, 
 
 ## 📏 Cross-skill conventions
 
-These apply to every skill in the grid. Details live in [`CLAUDE.md`](CLAUDE.md); the summary:
+These apply to every driver skill in the grid. They live canonically in
+the **[`sim-cli/`](sim-cli/SKILL.md)** shared skill — summary here:
 
-| Convention | One-line rule |
-|---|---|
-| **Category A inputs** | Physical decisions (geometry, materials, BCs, acceptance criteria). **Ask the user** if absent — pressure to "just use defaults" does NOT override this. |
-| **Category B inputs** | Operational defaults (processors, ui_mode, smoke-test iterations). May default; must disclose. |
-| **Category C inputs** | File-derivable (cell zones, surface names, solver version). Infer via a diagnostic snippet, not from reference examples. |
-| **Acceptance criteria** | `exit_code == 0` is **not** sufficient. Every task needs an outcome-based criterion (outlet temp in 28–35 °C, min mesh quality > 0.2, etc.). |
-| **Reference examples ≠ defaults** | Values in `<skill>/reference/examples/` describe a specific published test case. Offer them, never silently adopt them. |
-| **When to stop** | Solver fails to launch, snippet raises or returns `ok=false`, session state drifts from expectation, acceptance cannot be verified → report, don't silently retry. |
+| Convention | One-line rule | Full |
+|---|---|---|
+| **Category A inputs** | Physical decisions (geometry, materials, BCs, acceptance criteria). **Ask the user** if absent. | [input_classification.md](sim-cli/reference/input_classification.md) |
+| **Category B inputs** | Operational defaults (processors, ui_mode, smoke-test iterations). May default; must disclose. | [input_classification.md](sim-cli/reference/input_classification.md) |
+| **Category C inputs** | File-derivable (cell zones, surface names). Infer via a diagnostic snippet, not from reference examples. | [input_classification.md](sim-cli/reference/input_classification.md) |
+| **Acceptance criteria** | `exit_code == 0` is **not** sufficient. Every task needs an outcome-based criterion. | [acceptance.md](sim-cli/reference/acceptance.md) |
+| **Step-0 version probe** | Mandatory. `sim inspect session.versions` after connect; pick layered-folder content from the returned profile. | [version_awareness.md](sim-cli/reference/version_awareness.md) |
+| **Reference examples ≠ defaults** | Values in `<skill>/reference/examples/` describe a specific published test case. Offer them, never silently adopt them. | [input_classification.md](sim-cli/reference/input_classification.md) |
+| **When to stop** | Solver fails to launch, snippet raises or returns `ok=false`, session drifts, acceptance fails → report, don't silently retry. | [escalation.md](sim-cli/reference/escalation.md) |
 
 ---
 

--- a/comsol/SKILL.md
+++ b/comsol/SKILL.md
@@ -5,39 +5,48 @@ description: Use when driving COMSOL Multiphysics through the sim runtime — bu
 
 # comsol-sim
 
-You are connected to **COMSOL Multiphysics** via sim-cli. This file is
-the **index**. It tells you where to look for actual content — it does
-not contain the content itself.
+You are driving **COMSOL Multiphysics** via sim-cli in a **persistent
+session** (JPype Java API). This file is the **index** — it tells you
+where to look for content, not what the content says.
 
-The `/connect` response told you which active layer applies via:
-
-```json
-"skills": {
-  "root":               "<sim-skills>/comsol",
-  "active_sdk_layer":   null,        // single SDK line (mph 1.x), no overlay
-  "active_solver_layer":"6.4"        // or "6.2" / "6.1" / "6.0"
-}
-```
-
-Always read `base/`, then your active `solver/<version>/`. There is no
-`sdk/` overlay because all supported COMSOL versions pin a single
-`mph` line (1.2.x).
+> **First, read [`../sim-cli/SKILL.md`](../sim-cli/SKILL.md)** — it owns
+> the shared runtime contract (session lifecycle, Step-0 version probe,
+> input classification, acceptance, escalation). This skill covers only
+> the COMSOL-specific layer on top of that contract.
 
 ---
 
-## base/ — always relevant
+## COMSOL-specific layered content
+
+After `sim connect --solver comsol` and the shared-skill Step-0 probe,
+the returned `session.versions` payload tells you which COMSOL-specific
+subfolders to load:
+
+```json
+"session.versions": {
+  "profile":             "mph_1_2_comsol_6_4",
+  "active_sdk_layer":    null,        // single SDK line (mph 1.x), no overlay
+  "active_solver_layer": "6.4"        // or "6.2" / "6.1" / "6.0"
+}
+```
+
+There is no `sdk/` overlay because all supported COMSOL versions pin a
+single `mph` line (1.2.x). Always read `base/`, then your active
+`solver/<slug>/`.
+
+### `base/` — always relevant
 
 | Path | What's there |
 |---|---|
 | `base/workflows/block_with_hole/` | Steady-state thermal of a heated block with a cylindrical hole. 6 numbered Python steps (`00_create_geometry.py` … `05_plot_temperature.py`). The canonical "smallest end-to-end" reference for this driver. |
 | `base/workflows/surface_mount_package/` | More realistic SMD package thermal model. 6 numbered steps + a `README.md` describing the geometry and acceptance criteria. |
 
-Each numbered step is a self-contained snippet you can submit to
+Each numbered step is a self-contained snippet you submit via
 `sim exec` after `sim connect --solver comsol`. The snippets use the
 injected `model` object — they do NOT call `mph.start()` or open a
 client of their own.
 
-## solver/<active_solver_layer>/ — release specifics
+### `solver/<active_solver_layer>/` — release specifics
 
 Empty stubs by default; per-release deltas land here as discovered.
 
@@ -48,23 +57,28 @@ Empty stubs by default; per-release deltas land here as discovered.
 
 ---
 
-## Hard constraints
+## COMSOL-specific hard constraints
+
+These add to — do not replace — the shared skill's hard constraints.
 
 1. **Never call `mph.start()` or `client.create()` from a snippet.**
    sim-cli already started a COMSOL JVM and gave you a `model` handle.
    A second `start()` spawns a conflicting JVM.
 2. **Image export is broken on Windows.** Use the verification helpers
-   referenced in the workflow READMEs (slice/probe extraction → numeric
-   acceptance) instead of `model.result().export()` PNGs.
-3. **Acceptance ≠ exit code.** Always validate against a numeric
-   probe/extract from the relevant workflow's README.
+   referenced in the workflow READMEs (slice / probe extraction →
+   numeric acceptance) instead of `model.result().export()` PNGs. The
+   shared skill's `acceptance.md` explains why numeric acceptance
+   beats visual acceptance anyway.
 
 ---
 
 ## Required protocol (one paragraph)
 
-After `/connect` succeeds, pick a workflow under `base/workflows/` whose
-geometry and physics match the user's task, then execute its numbered
-snippets in order via `sim exec`, checking `last.result` after each step
-for `ok=true`. After the final step, evaluate against the workflow's
-acceptance criteria (typically a probe value with a tolerance).
+Follow the shared skill's required protocol for the **persistent
+session** model. COMSOL-specific steps: after `sim connect --solver
+comsol` and the Step-0 probe, pick a workflow under `base/workflows/`
+whose geometry and physics match the user's task, then execute its
+numbered snippets in order via `sim exec`, checking `sim inspect
+last.result` after each step for `ok=true`. After the final step,
+evaluate against the workflow's acceptance criteria (typically a probe
+value with a tolerance) per the shared skill's `acceptance.md`.

--- a/fluent/SKILL.md
+++ b/fluent/SKILL.md
@@ -1,101 +1,109 @@
 ---
 name: fluent-sim
-description: Use when an agent or engineer needs to drive an Ansys Fluent meshing or solver session through the sim runtime — incremental snippet execution, single-file workflows, persistent sessions via `sim connect`/`sim exec`/`sim inspect`, or one-shot script runs.
+description: Use when an agent or engineer needs to drive an Ansys Fluent meshing or solver session through the sim runtime — incremental snippet execution, single-file workflows, persistent sessions via `sim connect` / `sim exec` / `sim inspect`, or one-shot script runs.
 ---
 
 # fluent-sim
 
-You are connected to **Ansys Fluent** via sim-cli. This file is the
-**index**. It tells you where to look for actual content — it does not
-contain the content itself.
+You are driving **Ansys Fluent** via sim-cli in a **persistent session**.
+This file is the **index** — it tells you where to look for content,
+not what the content says.
 
-The `/connect` response told you which active layers apply via:
-
-```json
-"skills": {
-  "root":               "<sim-skills>/fluent",
-  "active_sdk_layer":   "0.38",   // or "0.37"
-  "active_solver_layer":"25.2"    // or null
-}
-```
-
-Always read the index for `base/`, then your active `sdk/<version>/`,
-then your active `solver/<version>/`. Later layers override earlier
-ones on identically-named files.
+> **First, read [`../sim-cli/SKILL.md`](../sim-cli/SKILL.md)** — it owns
+> the shared runtime contract (session lifecycle, Step-0 version probe,
+> input classification, acceptance, escalation). This skill covers only
+> the Fluent-specific layer on top of that contract.
 
 ---
 
-## base/ — always relevant
+## Fluent-specific layered content
 
-Concepts, terminology, and version-agnostic control patterns:
+After `sim connect --solver fluent` and the shared-skill Step-0 probe,
+the returned `session.versions` payload tells you which Fluent-specific
+subfolders to load:
+
+```json
+"session.versions": {
+  "profile":             "pyfluent_0_38_modern",
+  "active_sdk_layer":    "pyfluent-0.38",  // or "pyfluent-0.37"
+  "active_solver_layer": "25.2"            // or null
+}
+```
+
+Always read `base/`, then your active `sdk/<slug>/`, then your active
+`solver/<slug>/`. Later layers override earlier ones on identically
+named files.
+
+### `base/` — always relevant
 
 | Path | What's there |
 |---|---|
-| `base/reference/task_templates.md` | Per-workflow input templates with "Must ask if missing" lists. **Always read first** to identify Category A inputs before any `sim exec`. |
-| `base/reference/runtime_patterns.md` | The incremental "execute → inspect last.result → decide → next" loop. The canonical control protocol. |
-| `base/reference/acceptance_checklists.md` | Per-workflow acceptance criteria. Used to evaluate the final session state. |
+| `base/reference/task_templates.md` | Per-workflow input templates with "Must ask if missing" lists. **Always read first** to identify Category A inputs (per the shared skill's `input_classification.md`) before any `sim exec`. |
+| `base/reference/runtime_patterns.md` | Fluent-specific dependency chains (meshing task ordering, solver step ordering). For the generic connect/exec/inspect/disconnect loop, see the shared skill's `lifecycle.md`. |
+| `base/reference/acceptance_checklists.md` | Per-workflow acceptance criteria for the packaged Fluent workflows. |
 | `base/reference/api_discovery.md` | `dir()` / `child_names` patterns for finding renamed attributes when an API call fails. |
 | `base/reference/tui_vs_settings.md` | When to prefer the Settings API vs the legacy TUI. |
 | `base/reference/pyfluent_overview.md` | Quick orientation: what PyFluent is, what each module does. |
-| `base/snippets/` | Numbered EX-01 step snippets (`01_read_case.py` through `08c_extract_all_fields.py`). Built for the modern (0.38) dialect; portable to 0.37 with the material-accessor swap noted in `sdk/0.37/notes.md`. |
+| `base/snippets/` | Numbered EX-01 step snippets (`01_read_case.py` through `08c_extract_all_fields.py`). Built for the modern (0.38) dialect; portable to 0.37 with the material-accessor swap noted in `sdk/pyfluent-0.37/notes.md`. |
 | `base/workflows/` | Multi-step demo scripts: meshing (watertight + fault-tolerant), solver exhaust manifold, flipchip thermal. |
 
-## sdk/<active_sdk_layer>/ — PyFluent API specifics
+### `sdk/<active_sdk_layer>/` — PyFluent API specifics
 
-Read the layer matching your `active_sdk_layer` field:
-
-- `sdk/0.38/` — current PyFluent line.
+- `sdk/pyfluent-0.38/` — current PyFluent line.
   - `cheat_sheet.md` — most common API calls in one file.
   - `examples/` — full pyfluent.docs.pyansys.com examples (mixing_elbow,
     ahmed_body, conjugate_heat_transfer, …). Each is a working Python
     script you can quote from.
-  - `user_guide/` — the upstream PyFluent user guide, mirrored. Search
-    here when an API call surprises you.
-- `sdk/0.37/` — legacy line.
+  - `user_guide/` — the upstream PyFluent user guide, mirrored.
+- `sdk/pyfluent-0.37/` — legacy line.
   - `notes.md` — the one accessor difference vs 0.38 that bites EX-01.
 
-## solver/<active_solver_layer>/ — Fluent release specifics
+### `solver/<active_solver_layer>/` — Fluent release specifics
 
 - `solver/25.2/` — Fluent 25R2 (v252) quirks (currently empty stub).
 
-## skill_tests/ and tests/ (top-level, not part of the layered tree)
+### `skill_tests/` and `tests/` (top-level, QA-only)
 
-These are QA artifacts for the skill itself, not content the LLM should
-load during a normal session:
-
-- `skill_tests/` — natural-language and execution test cases used to
-  validate the skill end-to-end against real Fluent.
-- `tests/` — pytest integration tests.
+Not loaded during a normal session. These are natural-language and
+pytest test cases used to validate the skill end-to-end against real
+Fluent.
 
 ---
 
-## Hard constraints (apply to every session)
+## Fluent-specific hard constraints
+
+These add to — do not replace — the shared skill's hard constraints.
 
 1. **Never call `pyfluent.launch_fluent()` from a snippet.** sim-cli
-   already started the Fluent process. A second `launch_fluent()`
+   already started the Fluent process. A second `launch_fluent()` call
    spawns a conflicting instance.
-2. **Never invent Category A defaults.** Geometry params, materials,
-   BCs, acceptance criteria — if missing, ask the user.
-3. **Acceptance ≠ exit code.** A snippet can return `ok=true` and the
-   simulation can still be physically wrong. Validate against
-   `base/reference/acceptance_checklists.md` after the final step.
+2. **Mode cannot change mid-session.** Meshing vs solver is chosen at
+   `sim connect --mode …` time. To change modes, disconnect and
+   reconnect.
+3. **Meshing dependency chain is strict.** The watertight workflow
+   requires `InitializeWorkflow → ImportGeometry → LocalSizing →
+   SurfaceMesh → DescribeGeometry → UpdateBoundaries → UpdateRegions →
+   BoundaryLayers → VolumeMesh → SwitchToSolver` in order. See
+   `base/reference/runtime_patterns.md` for the full Fluent dependency
+   rules.
 
 ---
 
 ## Required protocol (one paragraph)
 
-After `/connect` succeeds: read the active task template from
-`base/reference/task_templates.md`, gather Category A inputs from the
-user, then execute incrementally per `base/reference/runtime_patterns.md`,
-checking `last.result` after every step. Use snippets from
+Follow the shared skill's required protocol for the **persistent
+session** model. Fluent-specific steps: after `sim connect --solver
+fluent --mode <meshing|solver>` and the Step-0 probe, read the active
+task template from `base/reference/task_templates.md`, gather Category
+A inputs from the user, then execute incrementally via `sim exec`,
+checking `sim inspect last.result` after every step. Use snippets from
 `base/snippets/` (translating material-accessor calls per
-`sdk/<your-version>/notes.md` if applicable). After the final step,
+`sdk/pyfluent-0.37/notes.md` if applicable). After the final step,
 evaluate against the relevant checklist in
 `base/reference/acceptance_checklists.md`.
 
-For the canonical end-to-end example (the EX-01 mixing-elbow case),
-the snippet sequence is `01_read_case` → `02_mesh_check` →
-`03_setup_physics` → `04_setup_material` → `05a_setup_bcs_ex01_ex05` →
-`06_hybrid_init` → `07_run_150_iter` → `08a_extract_outlet_temp`,
-followed by acceptance evaluation against the EX-01 row of
-`acceptance_checklists.md`.
+For the canonical end-to-end example (EX-01 mixing-elbow), the snippet
+sequence is `01_read_case` → `02_mesh_check` → `03_setup_physics` →
+`04_setup_material` → `05a_setup_bcs_ex01_ex05` → `06_hybrid_init` →
+`07_run_150_iter` → `08a_extract_outlet_temp`, followed by acceptance
+evaluation against the EX-01 row of `acceptance_checklists.md`.

--- a/fluent/base/reference/runtime_patterns.md
+++ b/fluent/base/reference/runtime_patterns.md
@@ -1,140 +1,73 @@
-# Runtime Control Patterns — fluent-sim v0
+# Fluent-specific runtime dependencies
 
-> These are **control patterns**, not code templates.
-> Each pattern describes agent decision logic, not Python syntax.
+The generic connect / exec / inspect / disconnect loop, step-execution
+pattern, state-query pattern, failure handling, and acceptance
+evaluation all live in the shared sim-cli skill:
 
----
+- [`sim-cli/reference/lifecycle.md`](../../../sim-cli/reference/lifecycle.md) — patterns 0–6
+- [`sim-cli/reference/command_surface.md`](../../../sim-cli/reference/command_surface.md)
+- [`sim-cli/reference/escalation.md`](../../../sim-cli/reference/escalation.md)
+- [`sim-cli/reference/acceptance.md`](../../../sim-cli/reference/acceptance.md)
 
-## Pattern 0 — Session Lifecycle
-
-```
-CONNECT → [STEP × N] → DISCONNECT
-```
-
-- One session per task. Do not reuse a session across unrelated tasks.
-- Connect with the correct `--mode` (meshing vs. solver). Mode cannot change mid-session.
-- Always disconnect explicitly, even if steps failed.
+This file covers only the **Fluent-specific** dependency rules that the
+generic patterns do not capture.
 
 ---
 
-## Pattern 1 — Connect + Verify
+## Pattern 7 — Multi-step dependency ordering
 
-**When**: At the start of every task.
+**Rule**: never send step N+1 before step N is confirmed successful.
+This is a Fluent rule because the meshing and solver task lists are
+stateful — an out-of-order call mutates session state in ways that are
+hard to undo.
 
-**Actions**:
-1. Run `sim connect --mode <mode> --ui-mode <ui_mode> --processors <N>`
-2. Check exit code = 0
-3. Run `sim query session.summary`
-4. Verify: `connected=true`, `mode=<expected>`, `run_count=0`
+### Meshing (watertight)
 
-**If verification fails**: Stop. Report to user. Do not proceed with workflow steps.
-
----
-
-## Pattern 2 — Step Execution Loop
-
-**When**: For each workflow step.
-
-```
-write code → sim run --code-file <tmp> --label <label>
-         ↓
-     exit code?
-       0 → query last.result → ok=true? → continue
-                                        → ok=false? → STOP, report
-       ≠0 → STOP, report
-```
-
-**Key principle**: Each step is a checkpoint. The loop does not advance until the current step is confirmed successful.
-
-**Label convention**: Use descriptive labels (`init-workflow`, `import-geometry`, `surface-mesh`, etc.). Labels appear in `session.summary.run_count` and log files — they are the audit trail.
-
----
-
-## Pattern 3 — State Query
-
-**When**: After any step that changes session state, or when verifying a precondition.
-
-Available queries:
-
-| Query | Returns | Use when |
-|---|---|---|
-| `sim query session.summary` | `connected`, `mode`, `run_count` | Verifying session health, counting completed steps |
-| `sim query last.result` | `ok`, `label`, `result`, `stdout`, `stderr` | Checking step outcome and extracted values |
-| `sim query workflow.summary` | Workflow task list and states | Debugging meshing workflow task sequence |
-| `sim query field.catalog` | Available fields/variables | Pre-processing before result extraction |
-
-**Do not skip queries** between steps that depend on each other. For example: do not send the volume mesh step before confirming the surface mesh step succeeded.
-
----
-
-## Pattern 4 — Acceptance Evaluation
-
-**When**: After the final step of a workflow.
-
-**Actions**:
-1. Run `sim query session.summary` → verify `run_count` matches expected step count
-2. Run `sim query last.result` → verify `result` object contains expected fields
-3. Compare extracted values against the acceptance checklist for this workflow type
-4. If all criteria pass → task is COMPLETE
-5. If any criterion fails → task is INCOMPLETE, report which criteria failed
-
-**Critical distinction**:
-- "The script ran without error" ≠ task complete
-- "The acceptance checklist is satisfied" = task complete
-
----
-
-## Pattern 5 — Failure Handling
-
-**When**: Any step fails (non-zero exit, `ok=false`, exception in stderr).
-
-**Actions**:
-1. Read `last.result.stderr` for the exception message
-2. Read `last.result.stdout` for any partial output
-3. Check `session.summary.run_count` to confirm which steps completed
-4. Do NOT silently retry. Report to user with:
-   - Which step failed
-   - The error message
-   - Steps completed before the failure
-   - Whether the session is still alive (can the user inspect it?)
-
-**Do not attempt automated error recovery in v0.** Recovery strategies are a v1 concern.
-
----
-
-## Pattern 6 — Disconnect + Report
-
-**When**: At the end of every task (success or failure).
-
-**Actions**:
-1. Run `sim disconnect`
-2. Report to user:
-   - Workflow type and mode
-   - Steps completed (labels, run_count)
-   - Key extracted values (cell count, residuals, mass flow rate, etc.)
-   - Whether acceptance criteria were satisfied
-   - Any warnings or non-fatal issues observed in stdout
-
-**Format**: Structured summary, not a narrative. Values should be explicit.
-
----
-
-## Pattern 7 — Multi-Step Dependency Ordering
-
-**Rule**: Never send step N+1 before step N is confirmed successful.
-
-**Common dependency chains**:
-
-Meshing (watertight):
 ```
 InitializeWorkflow → ImportGeometry → LocalSizing → SurfaceMesh
 → DescribeGeometry → UpdateBoundaries → UpdateRegions
 → BoundaryLayers → VolumeMesh → SwitchToSolver
 ```
 
-Solver:
+### Meshing (fault-tolerant)
+
+```
+InitializeWorkflow → ImportCAD → CreateRegions → LocalSizing
+→ GenerateSurfaceMesh → UpdateBoundaries → CreateVolumeMesh
+→ SwitchToSolver
+```
+
+### Solver
+
 ```
 ReadCase → ReadData → MeshCheck → Iterate → ExtractResults
 ```
 
-If a step is skippable (e.g., LocalSizing defaults are acceptable), explicitly note that it was skipped and why.
+If a step is skippable (e.g. `LocalSizing` defaults are acceptable),
+explicitly note in the report that it was skipped and why. Do not
+silently drop steps.
+
+---
+
+## Pattern 8 — Mode-specific flag rules
+
+`--mode meshing` and `--mode solver` are not interchangeable. Which
+snippets are valid depends on the mode:
+
+| Mode | Valid snippet families |
+|---|---|
+| `meshing` | Watertight / fault-tolerant meshing snippets (`base/snippets/01_*` through pre-switch) |
+| `solver` | Post-`SwitchToSolver` snippets (`05a_setup_bcs_*` onward) |
+
+Running a solver snippet in meshing mode (or vice versa) fails with
+`AttributeError` on a missing module — there is no informative runtime
+check, so the agent must respect the mode.
+
+---
+
+## Pattern 9 — Settings vs TUI selection
+
+See `tui_vs_settings.md`. Short version: prefer the Settings API for
+new workflows; fall back to TUI commands only for features the Settings
+API has not yet surfaced (named expression tagging in 0.37, some
+solution-controls knobs). The Settings API is the durable interface.

--- a/matlab/SKILL.md
+++ b/matlab/SKILL.md
@@ -5,39 +5,47 @@ description: Use when running MATLAB scripts through the sim runtime — current
 
 # matlab-sim
 
-You are connected to **MATLAB** via sim-cli. This file is the **index**.
-It tells you where to look for actual content — it does not contain the
-content itself.
+You are driving **MATLAB** via sim-cli in the **one-shot batch** model.
+This file is the **index** — it tells you where to look for content,
+not what the content says.
 
-The `/connect` response told you which active layer applies via:
+> **First, read [`../sim-cli/SKILL.md`](../sim-cli/SKILL.md)** — it owns
+> the shared runtime contract (command surface, one-shot lifecycle,
+> Step-0 version probe, input classification, acceptance, escalation).
+> This skill covers only the MATLAB-specific layer on top of that
+> contract.
+
+---
+
+## MATLAB-specific layered content
+
+`sim inspect session.versions` (run against a short-lived session
+before your real `sim run`) returns:
 
 ```json
-"skills": {
-  "root":               "<sim-skills>/matlab",
-  "active_sdk_layer":   "24.1",      // or "24.2" / "23.2"
-  "active_solver_layer":null         // engine version IS the release pin
+"session.versions": {
+  "profile":             "matlabengine_24_1",  // or 24.2 / 23.2
+  "active_sdk_layer":    "24.1",                // matlabengine package version
+  "active_solver_layer": null                   // engine version IS the release pin
 }
 ```
 
 `active_sdk_layer` is the matlabengine package version. There is no
 separate `solver/` overlay because each matlabengine X.Y is rigidly
-coupled to one MATLAB release (24.1 ↔ R2024a, 24.2 ↔ R2024b, etc.).
+coupled to one MATLAB release (24.1 ↔ R2024a, 24.2 ↔ R2024b, …).
 
-Always read `base/`, then your active `sdk/<version>/`. Later layers
-override earlier ones on identically-named files.
+Always read `base/`, then your active `sdk/<slug>/`.
 
----
-
-## base/ — always relevant
+### `base/` — always relevant
 
 | Path | What's there |
 |---|---|
-| `base/reference/` | MATLAB control patterns: how to pass numpy arrays to engine, how to read engine.workspace, how to surface MATLAB errors as Python exceptions. |
+| `base/reference/` | MATLAB-specific control patterns: how to pass numpy arrays to engine, how to read engine.workspace, how to surface MATLAB errors as Python exceptions. |
 | `base/snippets/` | Ready-made `sim run` payloads for common analyses. |
 | `base/workflows/` | End-to-end multi-script examples. |
 | `base/driver_upgrade.md` | Process notes for bumping the matlabengine SDK pin. |
 
-## sdk/<active_sdk_layer>/ — engine-version specifics
+### `sdk/<active_sdk_layer>/` — engine-version specifics
 
 Empty stubs by default; per-engine deltas land here as discovered.
 
@@ -45,28 +53,37 @@ Empty stubs by default; per-engine deltas land here as discovered.
 - `sdk/24.1/notes.md` — matlabengine 24.1 / R2024a
 - `sdk/23.2/notes.md` — matlabengine 23.2 / R2023b
 
-## tests/ (top-level, not part of the layered tree)
+### `tests/` (top-level, QA-only)
 
-QA artifacts for the skill itself. Not loaded during a normal session.
+Not loaded during a normal session.
 
 ---
 
-## Hard constraints
+## MATLAB-specific hard constraints
+
+These add to — do not replace — the shared skill's hard constraints.
 
 1. **MATLAB output is not structured by default.** Always wrap the
    final result in an explicit JSON line on stdout that the driver's
-   `parse_output()` can pick up. Free-form `disp()` output gets lost.
-2. **Don't leave a MATLAB desktop running.** v0 is one-shot per script;
-   the driver tears the engine down between calls. Don't write
-   snippets that depend on workspace state surviving across `sim run`
-   invocations.
+   `parse_output()` can pick up. Free-form `disp()` output gets lost —
+   the parser only picks up the **last** JSON object in stdout.
+2. **Don't depend on workspace survival across calls.** v0 is
+   one-shot per script; the driver tears the engine down between
+   `sim run` invocations. Do not write snippets whose correctness
+   depends on workspace state set by an earlier `sim run`.
+3. **No MATLAB desktop.** Driver launches headless. Do not add
+   `desktop` / `-desktop` flags — there is no display.
 
 ---
 
 ## Required protocol (one paragraph)
 
-Validate Category A inputs (the .m script(s), the data files they need,
-the acceptance criteria), then `sim run script.m --solver matlab`.
-After completion, parse the JSON line off stdout and evaluate against
-the user's acceptance criteria. For multi-step pipelines, chain
-`sim run` calls — each is its own engine lifecycle.
+Follow the shared skill's required protocol for the **one-shot batch**
+model. MATLAB-specific steps: validate the `.m` script exists and its
+dependencies (data files, toolboxes) are on the MATLAB path; confirm
+the final script line emits a structured JSON object on stdout; run
+`sim run <script.m> --solver matlab`; parse the JSON line from stdout
+(the driver does this via `parse_output()`) and evaluate against the
+user's acceptance criterion per the shared skill's `acceptance.md`.
+For multi-step pipelines, chain `sim run` calls — each is its own
+engine lifecycle with no shared state.

--- a/sim-cli/SKILL.md
+++ b/sim-cli/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: sim-cli
+description: Use whenever driving any solver through sim-cli — shared session lifecycle, command surface, input classification, version awareness, acceptance, and escalation. Load alongside the solver-specific SKILL.md (fluent-sim, matlab-sim, comsol-sim, …) — this skill owns the runtime contract; the driver skill owns the solver-specific parts.
+---
+
+# sim-cli
+
+You are driving a solver through the **sim-cli** runtime. This skill
+owns the runtime contract that applies to **every** solver — session
+lifecycle, command surface, input validation, version awareness,
+acceptance semantics, escalation triggers.
+
+Each driver-specific skill (`fluent-sim`, `matlab-sim`, `comsol-sim`, …)
+layers on top of this one. The driver skill owns only:
+
+- Solver-specific hard constraints (e.g. "never call `pyfluent.launch_fluent()`")
+- Solver-specific dependency chains (e.g. Fluent meshing `InitializeWorkflow → ImportGeometry → …`)
+- Solver-specific artifacts (snippets, workflows, reference, SDK/solver layer notes)
+
+If a rule applies to more than one driver, it belongs here.
+
+---
+
+## How to use this skill
+
+1. Read the driver skill's `SKILL.md` first to learn what solver you're
+   driving and which execution model it uses.
+2. Read the sections below of **this** skill that match that model.
+3. Follow the **Required protocol** at the bottom.
+
+There are two execution models in sim-cli — the driver skill tells you
+which one applies:
+
+| Model | Used by | Lifecycle |
+|---|---|---|
+| **Persistent session** | fluent-sim, comsol-sim, mechanical-sim, mapdl-sim (session mode), workbench-sim, cfx-sim | `connect → exec × N → inspect → disconnect` |
+| **One-shot batch** | matlab-sim, starccm-sim, abaqus-sim, pybamm-sim, ansa-sim, flotherm-sim (GUI/FloSCRIPT variant), most OSS solvers | `run → parse_output → evaluate` |
+
+---
+
+## Reference files
+
+| Path | Read when |
+|---|---|
+| [`reference/command_surface.md`](reference/command_surface.md) | Before writing any `sim …` command — canonical CLI surface, verified against source. |
+| [`reference/lifecycle.md`](reference/lifecycle.md) | For the per-step decision loop. Covers both persistent and one-shot models. |
+| [`reference/version_awareness.md`](reference/version_awareness.md) | Every session — the mandatory Step-0 version probe and how to pick the right `sdk/` / `solver/` layer inside the driver skill. |
+| [`reference/input_classification.md`](reference/input_classification.md) | Before every task — Category A (ask), B (default + disclose), C (file-derive). |
+| [`reference/acceptance.md`](reference/acceptance.md) | At the end of every task — outcome-based evaluation. `exit_code == 0` alone is **not** acceptance. |
+| [`reference/escalation.md`](reference/escalation.md) | When something goes wrong — what to stop on, what to report. Do not silently retry. |
+
+---
+
+## Hard constraints (apply to every sim-cli session)
+
+1. **Never invent Category A defaults.** Physical decisions (geometry,
+   materials, BCs, acceptance criteria) must come from the user. User
+   pressure to "just use defaults" does **not** override this. See
+   `reference/input_classification.md`.
+2. **Step-0 version probe is mandatory.** After `sim connect` succeeds
+   (persistent) or before `sim run` (one-shot), call
+   `sim --host <host> inspect session.versions` (or the driver's
+   documented equivalent) and use the returned `profile` /
+   `active_sdk_layer` / `active_solver_layer` to pick the right files
+   inside the driver skill. If `profile` is empty, unknown, or
+   deprecated — **stop**. See `reference/version_awareness.md`.
+3. **Acceptance ≠ exit code.** A `sim run` or `sim exec` can return
+   `ok=true` and the simulation can still be physically wrong. Always
+   validate against an outcome-based criterion from the driver skill's
+   acceptance checklist. See `reference/acceptance.md`.
+4. **Never silently retry a failed step.** Report `stderr`, `stdout`,
+   and `run_count` / completion state; let the user decide the next
+   move. See `reference/escalation.md`.
+5. **Reference example values are not defaults.** Values in any
+   `.../examples/` directory describe a specific published test case.
+   You may offer them ("the mixing_elbow example uses 0.4 m/s — would
+   you like to use those values?") but must wait for explicit
+   confirmation before adopting them.
+
+---
+
+## Required protocol (one paragraph)
+
+Before any `sim` command: read the driver skill's `SKILL.md` and its
+"Required protocol" section. Classify inputs per
+`reference/input_classification.md`; ask the user for missing
+Category A inputs, including the acceptance criterion. Start the
+session (`sim connect` for persistent, nothing for one-shot). Run the
+Step-0 version probe (`sim inspect session.versions`) and pick the
+driver-skill subfolder that matches the returned profile. Execute per
+`reference/lifecycle.md` — incrementally for persistent sessions,
+validate-then-run for one-shot. After the final step (or the one-shot
+return), evaluate against the driver skill's acceptance checklist per
+`reference/acceptance.md`. On any failure, follow
+`reference/escalation.md` — do not silently retry.

--- a/sim-cli/reference/acceptance.md
+++ b/sim-cli/reference/acceptance.md
@@ -1,0 +1,87 @@
+# Acceptance semantics
+
+Across every sim-cli driver: **`exit_code == 0` alone does not satisfy
+acceptance.** A simulation can return `ok=true` and still be physically
+wrong — diverged but quietly, converged to the wrong basin, ran the
+correct model with the wrong BCs, hit the iteration cap before
+residuals dropped.
+
+Acceptance is always outcome-based.
+
+---
+
+## The distinction
+
+> "The script ran without error" ≠ task complete.
+> "The acceptance checklist is satisfied" = task complete.
+
+Exit code and `ok=true` are *preconditions*, not *acceptance*. If exit
+code is non-zero, acceptance cannot possibly be met; if it is zero,
+acceptance still has to be checked.
+
+---
+
+## What counts as an acceptance criterion
+
+A good criterion is **outcome-based**, **bounded**, and **measurable**:
+
+- Outcome: describes the physical result, not the operation
+  (✅ "outlet temperature in 28–35 °C"; ❌ "the solver ran for 150 iterations")
+- Bounded: has an explicit tolerance or range, not just a target
+- Measurable: extractable from the solver via `sim inspect last.result`
+  (persistent) or `parse_output(stdout)` (one-shot)
+
+Examples by physics:
+
+| Domain | Good criterion |
+|---|---|
+| Thermal | Max junction T < 85 °C; peak T within ±2 K of reference |
+| CFD / flow | Outlet mass-flow balance within 1 % of inlet; all RMS residuals < 1e-4 |
+| Structural | Tip displacement within 5 % of analytical / reference |
+| Meshing | Min orthogonal quality > 0.2; max aspect ratio < 50 |
+| Battery | End-of-discharge voltage within 10 mV of reference |
+| Optimization | Pareto front has ≥ N non-dominated points at generation G |
+
+---
+
+## Where criteria live
+
+Each driver skill ships an `acceptance_checklists.md` (or equivalent
+per-workflow README) under `base/reference/` or `base/workflows/`.
+Those define the canonical criteria for each packaged workflow.
+
+For **user-supplied tasks** (not a packaged workflow), the acceptance
+criterion is a **Category A input** — ask the user for it. See
+[`input_classification.md`](input_classification.md).
+
+Acceptable shapes of a user answer:
+
+- "Max junction temp must be under 85 °C." ← outcome-based ✅
+- "Outlet mass flow within 1 % of inlet." ← outcome-based ✅
+- "Just run it." ← operation-based, **treat as missing Category A** ❌
+- "Let me know when it's done." ← operation-based, ❌
+
+---
+
+## Evaluation loop
+
+After the final step (persistent) or the single `sim run` return
+(one-shot):
+
+1. Verify preconditions: exit_code == 0, `ok=true`, `stderr` free of
+   ERROR lines.
+2. Extract the numeric value(s) the criterion needs — via
+   `sim inspect last.result` or `parse_output(stdout)`.
+3. Compare against the criterion. Record the comparison explicitly in
+   the final report: "`T_max = 82.3 °C` — criterion `< 85 °C` ✅".
+4. If any criterion fails — task is **INCOMPLETE**. Report which
+   criterion failed, the extracted value, and the gap.
+
+---
+
+## Acceptance vs escalation
+
+This file covers the "happy path" final check. If a step *fails
+outright* (non-zero exit, `ok=false`, exception in stderr), see
+[`escalation.md`](escalation.md) — that is not an acceptance failure,
+it is an execution failure, and it has its own reporting protocol.

--- a/sim-cli/reference/command_surface.md
+++ b/sim-cli/reference/command_surface.md
@@ -1,0 +1,122 @@
+# sim-cli command surface
+
+This is the canonical reference for `sim …` subcommands. Verified
+against `sim-cli/src/sim/cli.py`. If a driver skill or downstream doc
+disagrees, this file wins — fix the downstream doc.
+
+---
+
+## Global options (all commands)
+
+```
+sim [--host HOST] [--port PORT] [--json] <command> …
+```
+
+- `--host` — defaults to `localhost`. Use for remote `sim serve`
+  instances (e.g. a Windows box over Tailscale).
+- `--port` — defaults to `8765`.
+- `--json` — machine-readable output. Prefer when parsing in snippets;
+  human output is for terminals.
+
+---
+
+## One-shot execution
+
+### `sim run <script> --solver <solver>`
+
+Executes a script in a subprocess and exits. No persistent session. The
+driver's `parse_output(stdout)` extracts the JSON payload, which is
+returned on the `parsed_output` field in `--json` mode.
+
+```bash
+sim run analysis.m --solver matlab
+sim run job.k      --solver lsdyna
+```
+
+**Exit code**: 0 if the driver reports `ok=true`, non-zero otherwise.
+**Use for**: drivers that have no persistent-session model (MATLAB v0,
+most OSS solvers, Abaqus `.inp`, LS-DYNA `.k`).
+
+---
+
+## Persistent session
+
+### `sim serve [--host HOST] [--port PORT] [--reload]`
+
+Starts the HTTP server. Usually launched once per host; `sim connect`
+on a local host auto-starts a server if none is running. Run manually
+for remote boxes.
+
+### `sim connect --solver <solver> [--mode MODE] [--ui-mode UI] [--processors N]`
+
+Launches the solver inside the server and holds a session open.
+Solver-specific flags:
+
+| Flag | Drivers that use it |
+|---|---|
+| `--mode meshing \| solver` | `fluent` |
+| `--ui-mode gui \| headless` | `fluent`, `mechanical`, `comsol` |
+| `--processors N` | any MPI-capable solver |
+
+The driver skill documents which flags its driver accepts and what the
+defaults mean.
+
+### `sim exec [<code>] [--file PATH] [--label LABEL]`
+
+Runs a snippet inside the live session. Pass code as a positional arg,
+or read from a file with `--file`. `--label` is free-text; it shows up
+in `session.summary.run_count` and log files — use descriptive labels
+like `import-geometry`, `hybrid-init`.
+
+```bash
+sim exec --file 03_setup_physics.py --label setup-physics
+sim exec "model.mesh.check()"       --label mesh-check
+```
+
+**Exit code**: 0 if the snippet's `ok=true`, `2` on `ok=false`.
+
+### `sim inspect <target>`
+
+Queries live session state. Common targets across all drivers:
+
+| Target | Returns |
+|---|---|
+| `session.summary` | `connected`, `mode`, `run_count` |
+| `session.versions` | `sdk`, `solver`, `profile`, `active_sdk_layer`, `active_solver_layer`, `env_path` — **use at Step 0** |
+| `session.mode` | Current session mode (driver-dependent) |
+| `last.result` | `ok`, `label`, `result`, `stdout`, `stderr` from the most recent `exec` |
+| `workflow.summary` | Workflow task states (Fluent meshing) |
+| `field.catalog` | Available fields for post-processing (Fluent) |
+
+Driver-specific targets are documented in each driver skill's SKILL.md
+(e.g. `ls_dyna: deck.summary, deck.text`; `mechanical:
+mechanical.project_directory`).
+
+### `sim disconnect [--stop-server]`
+
+Tears down the solver session. By default the server keeps running so
+subsequent `connect` calls are instant. `--stop-server` also kills the
+server (equivalent to `sim stop` afterwards).
+
+---
+
+## Housekeeping
+
+| Command | Purpose |
+|---|---|
+| `sim ps` | List active sessions on the server |
+| `sim stop` | Stop the running server |
+| `sim check <solver>` | On-demand driver detection without holding a session |
+
+---
+
+## Common drift to avoid
+
+These are mistakes found in existing driver skills — do not repeat:
+
+- `sim query …` → it is **`sim inspect …`**. `query` was the old name;
+  the current CLI does not expose `query` as a subcommand.
+- `sim exec --code-file PATH` → it is **`sim exec --file PATH`**. There
+  is no `--code-file` flag.
+- `sim run … --solver matlab` **cannot take `--mode`**. Mode is a
+  persistent-session concept (`sim connect --mode …`).

--- a/sim-cli/reference/escalation.md
+++ b/sim-cli/reference/escalation.md
@@ -1,0 +1,91 @@
+# Escalation — when to stop and report
+
+Across all sim-cli drivers: **do not silently retry failed steps.**
+Agents that burn through 50 retries leave the user with unusable session
+state and no diagnostic signal. Stop early, report cleanly, let the
+user decide.
+
+---
+
+## Stop-and-report triggers
+
+Stop on any of these. Do not attempt automated recovery.
+
+| Trigger | Signal |
+|---|---|
+| Driver unavailable | `sim connect` / `sim run` exits non-zero with "no driver for `<solver>`" or "solver not installed" |
+| Runtime profile empty / unknown / deprecated | `sim inspect session.versions` returns `profile: null` or a value not in the driver's `compatibility.yaml` (see [`version_awareness.md`](version_awareness.md)) |
+| Step failed (persistent) | `sim exec` non-zero exit, or `sim inspect last.result` returns `ok=false`, or `stderr` contains an exception |
+| Step failed (one-shot) | `sim run` non-zero exit, or `stderr` contains ERROR lines, or `parse_output(stdout)` returns `{}` when a payload was expected |
+| Session state inconsistent | `sim inspect session.summary` shows unexpected `run_count` or `mode` after a step |
+| Acceptance failed | After all steps succeeded, an acceptance criterion was not met — see [`acceptance.md`](acceptance.md) |
+
+---
+
+## What to report
+
+Always include, in a structured summary:
+
+1. **What was attempted** — solver, workflow, the failing step's label.
+2. **The error signal** — exit code, first ~20 lines of `stderr`,
+   exception class and message if present.
+3. **Completion state** — how many steps succeeded before the failure
+   (`session.summary.run_count` for persistent; "reached step N of M"
+   for one-shot).
+4. **Session liveness** — for persistent sessions, whether the session
+   is still alive (`sim inspect session.summary → connected`). If it
+   is, the user can inspect it manually before you disconnect.
+5. **What would need to change to try again** — a missing input, a
+   different mode, an incompatible SDK version, a corrupted file.
+
+Format example (persistent):
+
+```
+[sim] FAILED at step 4/8 (label="setup-material")
+  error: AttributeError: 'FluentSettings' has no attribute 'general'
+  session: connected=true, mode=solver, run_count=3
+  stdout (last 5 lines): …
+  stderr (last 5 lines): …
+
+Likely cause: PyFluent 0.37 dialect used against 0.38 runtime.
+The active_sdk_layer returned by Step-0 was "pyfluent-0.37"
+but the snippet is from base/snippets/ (0.38 dialect).
+To proceed: either swap to sdk/pyfluent-0.37/snippets/, or upgrade
+the environment to pyfluent 0.38.
+```
+
+Format example (one-shot):
+
+```
+[sim] FAILED (exit=2) during sim run analysis.m --solver matlab
+  stderr: Undefined function 'cfd_solve' for input arguments of type 'double'.
+  stdout: (empty)
+
+Likely cause: cfd_solve is not on the MATLAB path in the current environment.
+To proceed: either add the toolbox containing cfd_solve to the MATLAB
+path, or supply a script that uses a built-in solver.
+```
+
+---
+
+## What *not* to do
+
+- ❌ Silently retry with different parameters ("maybe it'll work this
+  time").
+- ❌ Disconnect the session before the user has had a chance to inspect
+  it — if it is still alive, leave it alive.
+- ❌ Edit the user's input files to "fix" the error. If inputs are
+  wrong, ask the user.
+- ❌ Swap to a different solver because the current one failed. The
+  user picked this solver; respect that.
+- ❌ Claim success because "the exit code was 0" when an acceptance
+  criterion was not met. See [`acceptance.md`](acceptance.md).
+
+---
+
+## Automated recovery is out of scope
+
+v0 sim-cli skills do **not** attempt automated error recovery. Recovery
+strategies (retry with different `--processors`, fall back to a simpler
+mesh, switch from `pyfluent.launch_fluent` to `sim serve`, …) are a v1
+concern and require explicit user opt-in.

--- a/sim-cli/reference/input_classification.md
+++ b/sim-cli/reference/input_classification.md
@@ -1,0 +1,97 @@
+# Input classification
+
+Every sim-cli task starts with the same question: **which inputs must
+the user supply, which may I default, and which can I derive from the
+files in front of me?** The answer is the same three-bucket rule across
+every driver.
+
+---
+
+## Category A — Physical decision inputs
+
+**Must ask the user if absent. Non-negotiable.**
+
+These define *what the simulation physically represents*:
+
+- Geometry parameters (dimensions, feature sizes, orientations)
+- Materials and material properties
+- Boundary conditions (inlet velocities, heat loads, wall temperatures, …)
+- Initial conditions
+- Physics model choices (laminar vs turbulent, steady vs transient, …)
+- **Acceptance criterion** — the outcome-based check that decides
+  whether the task is complete (see [`acceptance.md`](acceptance.md))
+
+User pressure to "just use defaults" does **not** override this. Phrases
+like "just run it" / "跑完就好" / "use whatever makes sense" describe an
+operation, not an outcome — treat them as a missing Category A input and
+ask.
+
+Values lifted from a reference example (`sdk/*/examples/`, workflow
+READMEs, tutorial scripts) are **not defaults** — they describe a
+specific published test case. You may offer them explicitly ("the
+mixing_elbow example uses 0.4 m/s inlet — would you like to use those
+values?") but you must wait for the user's confirmation before
+adopting them.
+
+---
+
+## Category B — Operational inputs
+
+**May default. Must disclose.**
+
+These affect runtime / performance / convenience only, not what the
+simulation physically represents:
+
+- `--processors N` (parallelism)
+- `--ui-mode gui | headless`
+- `--mode meshing | solver` when only one makes sense for the task
+- Smoke-test iteration counts (e.g. "run 10 iters to check setup")
+- Output verbosity, log locations
+
+Defaults are fine, but surface them. A line like "Using 4 processors
+and headless UI — reply if you want different" is enough.
+
+---
+
+## Category C — File-derivable inputs
+
+**Infer from the actual files. Confirm if critical.**
+
+These are facts about the user's input files that the solver itself can
+tell you if you ask:
+
+- Mesh cell count, face zones, cell zones
+- Variables / fields present in a `.cas` / `.dat` / `.vtu`
+- Boundary names and types from a mesh file
+- Material IDs from an `.inp` deck
+- Element types, node counts
+
+**Rule**: derive these via a diagnostic snippet (`sim exec` with a tiny
+`dir()` / inspect call), **not** from a reference example of a similar
+case. A reference example describes its own files, not the user's.
+
+For anything downstream decisions depend on (e.g. naming a boundary as
+`inlet_cold` vs `inlet_hot`), confirm with the user before proceeding.
+
+---
+
+## Worked example
+
+> User: "Here's my mesh file `flipchip.msh`. Run a steady thermal
+> analysis."
+
+Classification:
+
+| Field | Category | Action |
+|---|---|---|
+| Ambient temperature | A | **Ask** — physical decision |
+| Chip heat load | A | **Ask** — physical decision |
+| Solver mode (steady) | A | User stated it |
+| Acceptance criterion | A | **Ask** — "what outcome would make this run successful? e.g. max junction temp < 85 °C" |
+| Number of processors | B | Default to 4, disclose |
+| UI mode | B | Default to headless, disclose |
+| Cell count, boundary names | C | Inspect via a diagnostic `sim exec` snippet |
+| Material properties | A | **Ask** — did not come with the mesh |
+
+Do not start the analysis until every Category A field has an explicit
+value from the user.

--- a/sim-cli/reference/lifecycle.md
+++ b/sim-cli/reference/lifecycle.md
@@ -1,0 +1,160 @@
+# Lifecycle control patterns
+
+These are **control patterns** — agent decision logic, not code
+templates. They cover the two sim-cli execution models; the driver
+skill tells you which one applies.
+
+---
+
+# Part A — Persistent session (connect / exec / inspect / disconnect)
+
+Used by Fluent, COMSOL, Mechanical, MAPDL (session mode), Workbench,
+CFX, and any other driver that holds a live solver process open.
+
+## Pattern 0 — Session lifecycle
+
+```
+CONNECT → STEP-0 VERSION PROBE → [STEP × N] → DISCONNECT
+```
+
+- One session per task. Do not reuse a session across unrelated tasks.
+- Connect with the correct driver-specific flags (mode, ui-mode,
+  processors). Mode cannot change mid-session.
+- Always disconnect explicitly, even if steps failed.
+
+## Pattern 1 — Connect + verify
+
+**When**: at the start of every task.
+
+1. Run `sim connect --solver <solver> [driver-specific flags]`.
+2. Check exit code = 0.
+3. Run `sim inspect session.summary`. Verify `connected=true`,
+   `mode=<expected>`, `run_count=0`.
+4. Run `sim inspect session.versions` → see
+   [`version_awareness.md`](version_awareness.md). Use the returned
+   `profile` / `active_sdk_layer` / `active_solver_layer` to pick the
+   right subfolder inside the driver skill.
+
+If verification fails: stop, report to the user. Do not proceed.
+
+## Pattern 2 — Step execution loop
+
+**When**: for each workflow step.
+
+```
+write code → sim exec --file <tmp> --label <label>
+         ↓
+     exit code?
+       0 → sim inspect last.result → ok=true? → continue
+                                   → ok=false? → STOP, report
+       ≠0 → STOP, report
+```
+
+Each step is a checkpoint. The loop does not advance until the current
+step is confirmed successful. Labels appear in `session.summary` and
+log files — they are the audit trail. Use descriptive labels
+(`import-geometry`, `surface-mesh`, `hybrid-init`) not generic ones
+(`step1`, `run`).
+
+## Pattern 3 — State query
+
+**When**: after any step that changes session state, or when verifying
+a precondition for the next step.
+
+See [`command_surface.md`](command_surface.md) for the full list of
+`sim inspect` targets. Do not skip inspects between steps that depend
+on each other — e.g. do not send a volume-mesh step before confirming
+surface-mesh succeeded.
+
+## Pattern 6 — Disconnect + report
+
+**When**: at the end of every task (success or failure).
+
+1. Run `sim disconnect`.
+2. Report:
+   - Solver and mode.
+   - Steps completed (labels and final `run_count`).
+   - Key extracted values (cell count, residuals, integral quantities, …).
+   - Whether the driver skill's acceptance checklist was satisfied.
+   - Any warnings or non-fatal issues observed in stdout.
+
+Format: structured summary, not a narrative. Values should be explicit.
+
+---
+
+# Part B — One-shot batch (run / parse / evaluate)
+
+Used by MATLAB (v0), STAR-CCM+ batch, Abaqus `.inp`, LS-DYNA `.k`,
+PyBaMM, ANSA, Flotherm (FloSCRIPT playback), and most OSS solvers.
+
+## Pattern 0 — Execution model
+
+```
+VALIDATE → RUN → EVALUATE → REPORT
+```
+
+There is no live session. The entire solve is one blocking `sim run …`
+call. All agent decisions happen **before** the call (input validation,
+acceptance-criterion confirmation) and **after** (output parsing,
+acceptance evaluation).
+
+## Pattern 1 — Validate before running
+
+**When**: before every `sim run` call.
+
+1. Classify inputs per
+   [`input_classification.md`](input_classification.md) and ask for any
+   missing Category A inputs — especially the acceptance criterion.
+2. Optionally call the driver's lint/check hook (if the driver skill
+   documents one — e.g. `driver.lint(pack_path)` for flotherm).
+3. Confirm the input files exist and are readable.
+
+If any check fails: stop. Report the specific failure. Do not call
+`sim run`.
+
+## Pattern 2 — Run and capture
+
+```bash
+sim run <script_or_deck> --solver <solver>
+# exit code, stdout, stderr, parsed_output returned on the result object
+```
+
+This call blocks until the solver exits. It may take seconds to hours.
+Do not assume a timeout — the solver manages its own execution, and a
+parent timeout that kills a long solve mid-run can leave an inconsistent
+workdir.
+
+## Pattern 3 — Evaluate output
+
+**When**: after `sim run` returns.
+
+```
+exit_code?
+  0  → check stderr for ERROR lines → check stdout non-empty → parse_output()
+                                                             → evaluate vs acceptance
+  ≠0 → STOP. Report exit_code + stderr. Task incomplete.
+```
+
+Structured data extraction uses the driver's `parse_output()` hook,
+which returns the last JSON object found in stdout (or `{}` if none).
+The driver skill tells you what fields to expect.
+
+## Pattern 4 — Report
+
+Same as Part A's Pattern 6, minus the `disconnect` step.
+
+---
+
+# Part C — Shared across both models
+
+## Acceptance evaluation
+
+See [`acceptance.md`](acceptance.md). Exit code and `ok=true` are
+necessary but not sufficient. Always evaluate against an outcome-based
+criterion from the driver skill's acceptance checklist.
+
+## Failure handling
+
+See [`escalation.md`](escalation.md). Never silently retry. When a step
+fails, capture `stderr`, `stdout`, and the completion state; report to
+the user; let them decide the next move.

--- a/sim-cli/reference/version_awareness.md
+++ b/sim-cli/reference/version_awareness.md
@@ -1,0 +1,100 @@
+# Version awareness — the Step-0 probe
+
+**Mandatory.** The first thing every task does after the session starts
+is probe the runtime version and use the result to pick the right
+subfolder inside the driver skill.
+
+---
+
+## Why this exists
+
+A snippet written for PyFluent 0.38 (uses `.general.material`) silently
+produces `AttributeError` on PyFluent 0.37 (which expects `.material`
+directly). A COMSOL 6.4 API call may not exist in 6.2. Without an
+explicit version check, the agent has to guess from the SDK package
+version — which is exactly the failure mode this probe eliminates.
+
+---
+
+## The probe
+
+After `sim connect` succeeds (persistent) — or at the start of a
+one-shot task, against a short-lived session:
+
+```bash
+sim --host <host> inspect session.versions
+```
+
+Returns:
+
+```json
+{
+  "sdk":                 {"name": "ansys-fluent-core", "version": "0.38.1"},
+  "solver":              {"name": "fluent",            "version": "25.2"},
+  "profile":             "pyfluent_0_38_modern",
+  "active_sdk_layer":    "pyfluent-0.38",
+  "active_solver_layer": "25.2",
+  "env_path":            "/.../.sim/envs/fluent-pyfluent-0-38"
+}
+```
+
+---
+
+## How to use the result
+
+The driver skill's `SKILL.md` tells you it has a layered folder
+structure:
+
+```
+<driver>/
+  base/                ← always relevant
+  sdk/<slug>/          ← SDK-specific deltas (empty for SDK-less drivers)
+  solver/<slug>/       ← solver-release deltas
+```
+
+Use the probe's fields to pick the right `<slug>`:
+
+- **`base/`** — always load.
+- **`sdk/<active_sdk_layer>/`** — load if set.
+- **`solver/<active_solver_layer>/`** — load if set.
+
+Later layers override earlier ones on identically-named files.
+
+Example (Fluent):
+
+```
+active_sdk_layer = "pyfluent-0.38"  → read sdk/pyfluent-0.38/
+active_solver_layer = "25.2"        → read solver/25.2/
+```
+
+If a driver skill has snippets in both `base/snippets/` and
+`sdk/<slug>/snippets/`, prefer the SDK-layer snippet when it exists for
+the same task — it was written against the exact API surface you're
+connected to.
+
+---
+
+## Failure modes — stop and surface
+
+Do **not** proceed silently if any of these hold:
+
+- `profile` is empty or missing.
+- `profile` is not listed in the driver's `compatibility.yaml`.
+- `profile` is marked `deprecated` in the driver's `compatibility.yaml`.
+- `active_sdk_layer` points to a directory that does not exist in the
+  driver skill.
+
+**Action**: stop, print the full `session.versions` payload, ask the
+user how to proceed (upgrade, downgrade, skip).
+
+Full contract: [`sim-cli/docs/architecture/version-compat.md`](https://github.com/svd-ai-lab/sim-cli/blob/main/docs/architecture/version-compat.md).
+
+---
+
+## Notes for SDK-less drivers
+
+Some drivers (flotherm, ansa, openfoam, CLI-native OSS solvers) have no
+Python SDK — they drive the solver via batch executables. For these,
+`active_sdk_layer` is typically `null` and only `active_solver_layer`
+(the release pin) matters. The probe shape is the same; just ignore
+the null fields.


### PR DESCRIPTION
## Summary

- Extract the sim-cli runtime contract (lifecycle, command surface, Step-0 version probe, input classification, acceptance, escalation) into a new top-level [`sim-cli/`](sim-cli/SKILL.md) skill so it isn't repeated across 38 driver skills.
- Pilot refactor 3 driver skills to load the shared skill first and keep only solver-specific content: a persistent CFD driver, a one-shot numerical-scripting driver, and a persistent multi-physics driver with GUI co-viewing.
- Fix drift found in existing docs: `sim query` -> **`sim inspect`**, `sim exec --code-file` -> **`sim exec --file`**.

## New files

- `sim-cli/SKILL.md` — entry point; all driver skills should point here first
- `sim-cli/reference/command_surface.md` — canonical subcommand surface, verified against `sim-cli/src/sim/cli.py` (`serve`, `run`, `connect`, `exec`, `inspect`, `ps`, `disconnect`, `stop`, `check`, `lint`, `screenshot`, `logs`), with a **Common drift to avoid** section
- `sim-cli/reference/lifecycle.md` — persistent and one-shot patterns
- `sim-cli/reference/input_classification.md` — Category A/B/C rules
- `sim-cli/reference/version_awareness.md` — `session.versions` Step-0 probe
- `sim-cli/reference/acceptance.md` — outcome-based acceptance criteria
- `sim-cli/reference/escalation.md` — stop-and-report triggers

## Pilot driver changes

- CFD-driver `SKILL.md` — now links to shared skill first; keeps solver-specific layered content and EX-01 protocol
- CFD-driver `base/reference/runtime_patterns.md` — **140 -> 73 lines** (patterns 0-6 moved to the shared skill; only solver-specific patterns 7-9 remain — this is where the duplication-reduction shows up most clearly)
- Numerical-scripting `SKILL.md` — one-shot pilot
- Multi-physics `SKILL.md` — persistent pilot
- `CLAUDE.md` + `README.md` — index the new skill

## Things reviewers should know

- **Pilot SKILL.mds didn't shrink raw line counts** (driver A 101->109, driver B 73->89, driver C 71->84). The reduction is in *solver-agnostic* content — what's left is clearly driver-specific. The duplication proof is in `runtime_patterns.md` (140->73) and the fact that future driver migrations no longer re-document the CLI surface.
- **35 remaining driver skills still work unchanged** — they keep their inline sim-cli docs and will be migrated in follow-up PRs. Nothing in this PR regresses them.
- **Docs were verified by source reading only**, not by a live `sim connect` probe against a running server. The `session.versions` schema (`active_sdk_layer` / `active_solver_layer`) is confirmed against `sim-cli/src/sim/drivers/*/compatibility.yaml` which already ships those fields. Subcommand names are confirmed against `@main.command()` decorators in `sim-cli/src/sim/cli.py`.

## Test plan

- [ ] Sanity-check skill loading: open the CFD-driver `SKILL.md`, follow the `../sim-cli/SKILL.md` link, confirm all six reference links resolve.
- [ ] Run at least one `sim connect --solver <driver>` session against sim-cli and confirm `sim inspect session.versions` returns the fields documented in `version_awareness.md`.
- [ ] For the one-shot pilot: run one `sim run script.<ext> --solver <driver>` and confirm `parse_output()` behavior matches `one-shot` section of `lifecycle.md`.
- [ ] Review the "Common drift to avoid" section in `command_surface.md` — are there other drifts worth adding?
