### PR TITLE
ltspice: add ltspice-sim skill (netlist authoring + platform dispatch)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,8 @@ Thumbs.db
 # Solver run output
 *.log
 *.trn
+*.raw
+*.op.raw
 flprt.*
 cleanup-fluent-*.bat
 

--- a/ltspice/SKILL.md
+++ b/ltspice/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: ltspice-sim
+description: Use when running LTspice circuit simulations through sim-cli — authoring `.net` netlists (and soon `.asc` schematics) for analog, power-electronics, and board-level designs, then reading structured `.meas` results from the log. Covers netlist authoring conventions, platform quirks (macOS 17.x vs Windows 26.x), and the sim-cli one-shot batch lifecycle.
+---
+
+# ltspice-sim
+
+You are driving **LTspice** via sim-cli in the **one-shot batch** model.
+This file is the **index** — it tells you where to look for content,
+not what the content says.
+
+> **First, read [`../sim-cli/SKILL.md`](../sim-cli/SKILL.md)** — it owns
+> the shared runtime contract (command surface, one-shot lifecycle,
+> Step-0 version probe, input classification, acceptance, escalation).
+> This skill covers only the LTspice-specific layer on top of that
+> contract.
+
+---
+
+## What LTspice is (and isn't)
+
+LTspice is the free SPICE3 simulator from Analog Devices. It has **no
+vendor Python API** — unlike Fluent (pyfluent), COMSOL (mph), or MATLAB
+(matlabengine). The sim-cli driver for LTspice is a thin adapter over
+[**sim-ltspice**](https://github.com/svd-ai-lab/sim-ltspice), a
+standalone Python library that IS the Python API for LTspice.
+
+Implication: everything in this skill stays identical whether you call
+`sim run foo.net --solver ltspice`, or import `sim_ltspice` directly in
+Python. The file format understanding and platform quirks are the same.
+
+## Input classification
+
+| Input | Accepted by sim-cli? | Notes |
+|---|---|---|
+| `.net` / `.cir` / `.sp` netlist | ✅ today | SPICE3 syntax; first line is title (ignored by solver); must contain at least one analysis directive |
+| `.asc` schematic (flat, library-local) | 🟡 sim-ltspice v0.1+ — on macOS goes through our native asc2net; on Windows/wine goes through LTspice's own `-netlist` | Schematic opens in LTspice GUI for human review |
+| `.asc` schematic (hierarchical or custom lib) | 🟡 Windows / wine only | Requires LTspice's own `-netlist` pass; on macOS raises `MacOSCannotFlatten` with guidance to run `sim --host <win1>` |
+| `.raw` / `.log` inputs | ❌ outputs only | Do not pass these to `sim run` |
+
+When you produce a netlist for an agent workflow, **always use `.net`**.
+It's the most portable (no LTspice version drift) and the sim-cli
+driver has the fewest edge cases for it.
+
+## Platform capabilities
+
+| Capability | macOS 17.x native | Windows 26.x | Linux + wine |
+|---|---|---|---|
+| `-b <netlist>` batch run | ✅ | ✅ | ✅ |
+| `-Run -b` | ❌ (ignored) | ✅ | ✅ |
+| `-ascii` raw output | ❌ | ✅ | ✅ |
+| `-netlist <asc>` schematic→netlist | ❌ | ✅ | ✅ |
+| `.asc` direct input to sim run | native asc2net only (flat + library-local) | full | full |
+| `.log` encoding | UTF-16 LE (no BOM) | UTF-8 | UTF-16 LE |
+| `.raw` header encoding | UTF-16 LE | UTF-16 LE | UTF-16 LE |
+
+If you need a feature Windows has and macOS lacks, route through
+`sim --host <win1>`. See `../sim-cli/SKILL.md` for the HTTP dispatch
+model.
+
+## Hard constraints (LTspice-specific)
+
+These add to — do not replace — the shared skill's hard constraints.
+
+1. **Every netlist must have an analysis directive.** At least one of
+   `.tran`, `.ac`, `.dc`, `.op`, `.noise`, `.tf`, `.four`. Without one,
+   LTspice returns exit code 0 but produces no useful output. `sim lint`
+   catches this.
+2. **Put `.meas` statements in the netlist, not in a config file.**
+   That's how structured values get surfaced on `sim logs last --field
+   measures`. Free-form `.print` output is harder to parse.
+3. **Never rely on workspace / state across `sim run` calls.** Each
+   invocation is a cold LTspice batch. Chain steps by writing out
+   intermediate `.net` variations in Python, not by stateful execution.
+4. **First line of a netlist is the title, always ignored.** Component
+   declarations start at line 2. A common mistake is putting `V1 in 0
+   1` on line 1 — LTspice silently treats it as comment text.
+5. **Use single-letter element prefixes.** `R` / `C` / `L` / `V` / `I`
+   / `D` / `Q` / `M` / `X`. Two-letter names like `R1a` are fine as
+   *instance labels*, but the first letter must match the element
+   kind.
+6. **Ground is net `0` (numeric zero).** Not `GND`, not `0v`. Other
+   names are arbitrary user-defined nets.
+
+## Required protocol (one paragraph)
+
+Follow the shared skill's required protocol for the **one-shot batch**
+model. LTspice-specific steps: validate the `.net` has a title line +
+at least one analysis directive + `.meas` statements for every metric
+the acceptance criterion checks; run `sim run <script.net> --solver
+ltspice`; read the structured results with `sim logs last --field
+measures` (returns `{"<name>": {"expr": "...", "value": <float>,
+"from": ..., "to": ...}}`); evaluate against acceptance per the shared
+skill's `acceptance.md`. For parameter sweeps, use `.step param` inside
+the netlist — one `sim run` covers the whole sweep; the resulting
+`.raw` has one dataset per step.
+
+## LTspice-specific layered content
+
+Always read `base/reference/`, then the relevant snippets + workflows.
+
+### `base/` — always relevant
+
+| Path | What's there |
+|---|---|
+| `base/reference/spice_directives.md` | Cheat sheet: `.tran`, `.ac`, `.dc`, `.op`, `.noise`, `.meas`, `.step`, `.param`, `.ic`, `.nodeset`, `.save` |
+| `base/reference/element_syntax.md` | R / C / L / V / I / D / Q / M / X instance syntax + common model options |
+| `base/reference/result_extraction.md` | How `.meas` values map to `sim logs last --field measures`; reading `.raw` trace names |
+| `base/reference/platform_dispatch.md` | When to use `--host <win1>`; macOS flat-asc-only constraint |
+| `base/snippets/rc_lowpass.net` | Minimal RC transient with one `.meas` |
+| `base/snippets/rlc_ac.net` | RLC AC sweep with `.meas` for resonance |
+| `base/snippets/inverting_amp.net` | Inverting op-amp with `.include LTC.lib` and gain `.meas` |
+| `base/snippets/param_sweep.net` | `.step param R 1k 100k dec 5` + acceptance via `.meas` max/min |
+| `base/workflows/meas_based_acceptance.md` | End-to-end: define acceptance → write `.meas` → `sim run` → read JSON → verify |
+| `base/workflows/monte_carlo.md` | Monte-Carlo via `.step` + `mc()` + Python loop with `sim run` per seed |
+
+### Documentation lookup
+
+LTspice ships an extensive offline help set on Windows at
+`%LOCALAPPDATA%\Programs\ADI\LTspice\LTspiceHelp\` (~145 HTML files,
+comprehensive SPICE + analysis reference). macOS ships no HTML help
+(the native app has an in-GUI help only).
+
+For authoritative syntax questions when on Windows:
+
+```bash
+sim --host 100.90.110.79 exec 'cat "%LOCALAPPDATA%\Programs\ADI\LTspice\LTspiceHelp\<topic>.html"'
+```
+
+For anyone else, consult the LTspice Users' Guide PDF (search
+"LTspice Getting Started Guide" — Analog Devices publishes it openly).
+
+### `tests/` (top-level, QA-only)
+
+Not loaded during a normal session. Mirrors the sibling skills'
+convention.
+
+---
+
+## Common pitfalls (save yourself a cycle)
+
+1. **Missing ground reference.** Every net that isn't declared somewhere
+   must be connected to something — LTspice flags singular matrices
+   cryptically. Always add ground (`FLAG 0` via the netlist is
+   implicit when you reference net `0`).
+
+2. **`.meas` misspelled as `.measure`.** Both work, but `.meas` is the
+   shorter form used in every example and our parser is tuned for it.
+
+3. **Windows `.log` encoding trap.** LTspice 26 writes UTF-8 logs;
+   LTspice 17 (macOS) writes UTF-16 LE. `sim-ltspice` handles both
+   transparently, but if you're reading the `.log` yourself with
+   `open()`, sniff the encoding.
+
+4. **Drive-letter paths in logs.** On Windows, the `.log` has a
+   `Files loaded:\nC:\Users\...\design.net` block. A naive regex
+   parser would see `C:` as a measure name. If you roll your own
+   log parser, exclude newlines from the expression capture. (Ours
+   does — see the sim-cli driver's regex.)
+
+5. **macOS `.asc` refusal.** If `sim run my.asc --solver ltspice`
+   errors with `MacOSCannotFlatten`, either (a) ensure the schematic
+   uses only shipped-library symbols and no hierarchy, or (b) route
+   via `sim --host <win1>`.

--- a/ltspice/SKILL.md
+++ b/ltspice/SKILL.md
@@ -105,14 +105,17 @@ Always read `base/reference/`, then the relevant snippets + workflows.
 |---|---|
 | `base/reference/spice_directives.md` | Cheat sheet: `.tran`, `.ac`, `.dc`, `.op`, `.noise`, `.meas`, `.step`, `.param`, `.ic`, `.nodeset`, `.save` |
 | `base/reference/element_syntax.md` | R / C / L / V / I / D / Q / M / X instance syntax + common model options |
-| `base/reference/result_extraction.md` | How `.meas` values map to `sim logs last --field measures`; reading `.raw` trace names |
+| `base/reference/result_extraction.md` | Three layers (`.meas` → `RawRead` cursors → arrays) + `eval` / `to_csv` / `to_dataframe`. Read before reaching for `.raw` |
 | `base/reference/platform_dispatch.md` | When to use `--host <win1>`; macOS flat-asc-only constraint |
 | `base/snippets/rc_lowpass.net` | Minimal RC transient with one `.meas` |
-| `base/snippets/rlc_ac.net` | RLC AC sweep with `.meas` for resonance |
+| `base/snippets/rlc_ac.net` | Series-RLC band-pass AC sweep — complex `.raw` traces, resonance `.meas` |
 | `base/snippets/inverting_amp.net` | Inverting op-amp with `.include LTC.lib` and gain `.meas` |
 | `base/snippets/param_sweep.net` | `.step param R 1k 100k dec 5` + acceptance via `.meas` max/min |
 | `base/workflows/meas_based_acceptance.md` | End-to-end: define acceptance → write `.meas` → `sim run` → read JSON → verify |
-| `base/workflows/monte_carlo.md` | Monte-Carlo via `.step` + `mc()` + Python loop with `sim run` per seed |
+| `base/workflows/regression_diff.md` | Two-run `.raw` comparison with `sim_ltspice.diff(a, b)`. Pin a golden `.raw`, gate refactor PRs on waveform equivalence |
+| `base/workflows/gui_review_handoff.md` | Python builds `.asc` → spawn LTspice GUI → human reviews / edits → re-read. Waveform viewer handoff. `sim.gui` pywinauto notes for Windows dialogs |
+| `base/workflows/param_sweep_postprocess.md` | `.step param` sweep → extract per-step scalars (`.meas`) or slice full traces (`RawRead.to_dataframe()` + axis-seam split) for plotting / custom math |
+| `base/workflows/monte_carlo.md` *(planned — not yet written)* | Monte-Carlo via `.step` + `mc()` + Python loop with `sim run` per seed |
 
 ### Documentation lookup
 

--- a/ltspice/base/reference/element_syntax.md
+++ b/ltspice/base/reference/element_syntax.md
@@ -1,0 +1,97 @@
+# Element syntax cheat sheet
+
+LTspice element lines follow SPICE3: `<name> <nodes...> <value-or-model>`.
+The **first letter of the name determines the element kind** — you
+cannot rename a resistor to `C_foo` and have it behave as a capacitor.
+
+| Kind | Prefix | Nodes | Tail form(s) |
+|---|---|---|---|
+| Resistor | `R` | 2 | `1k` · `1k tc=100u` · `{R_load}` |
+| Capacitor | `C` | 2 | `100n` · `100n ic=0 Rser=10m` |
+| Inductor | `L` | 2 | `10m` · `10m Rser=5m Rpar=1Meg` |
+| Voltage source | `V` | 2 | `5` · `AC 1` · `SINE(0 1 1k)` · `PULSE(0 5 0 1u 1u 1m 2m)` · `PWL(0 0 1m 5)` |
+| Current source | `I` | 2 | same source forms as `V` |
+| Diode | `D` | 2 | `<model-name>` e.g. `1N4148` |
+| BJT | `Q` | 3 or 4 | `<model>` — NPN/PNP |
+| MOSFET | `M` | 4 | `<model> L=1u W=10u` |
+| JFET | `J` | 3 | `<model>` |
+| Switch | `S` (voltage-ctrl) / `W` (current-ctrl) | 4 | `<model>` |
+| Subcircuit | `X` | ≥1 | `<subckt-name> <params>` — nodes before name |
+
+**Ground is net `0`.** Not `GND`, not `0v`. Treat it as a reserved
+identifier — LTspice references it everywhere.
+
+## Source descriptors (on `V` / `I`)
+
+Static DC: `V1 in 0 5`  → 5 V DC at `in`.
+
+AC analysis: `V1 in 0 AC 1` — magnitude 1, phase 0 for `.ac` sweeps.
+Can coexist with a static DC bias: `V1 in 0 2.5 AC 0.1`.
+
+Transient waveforms — the tail names a waveform generator:
+
+| Generator | Signature | Notes |
+|---|---|---|
+| `SINE(voff vampl f Td Df ϕ Ncycles)` | `SINE(0 1 1k)` — minimum form | Only first three are required |
+| `PULSE(v1 v2 Td Tr Tf Pw Per Ncycles)` | `PULSE(0 5 0 1u 1u 1m 2m)` | Square / pulse train |
+| `PWL(t1 v1 t2 v2 …)` | `PWL(0 0 1m 5 2m 0)` | Piecewise-linear |
+| `EXP(v1 v2 Td1 τ1 Td2 τ2)` | `EXP(0 1 0 10u 1m 100u)` | Exponential rise/fall |
+| `SFFM(voff vampl fc MDI fs)` | — | Single-frequency FM |
+| `PWL FILE=<path>` | `PWL FILE=stimulus.csv` | Table-driven |
+
+## Common tail options (quick reference)
+
+- Tolerance: `{R_val*(1+0.05*mc(0,0.05))}` — 5 % Gaussian Monte Carlo on
+  a param. Only evaluated under `.step` with seed.
+- `tc=<temperature-coefficient>` on R / C / L — linear TC vs. `.temp`.
+- `Rser=<Ω>` / `Rpar=<Ω>` — parasitic resistances on L / C.
+- `ic=<V>` on C / L — initial condition, honored by `.tran uic`.
+
+## Subcircuit usage (`X`)
+
+```spice
+* Using a subckt model (.lib / .subckt shipped with LTspice or your own)
+.include LTC.lib
+
+XU1 in+ in- vcc vee out LT1001   ; nodes first, subckt name last
+V1  vcc 0 15
+V2  vee 0 -15
+```
+
+Pin order for `X` is **whatever the `.subckt` header declares** — get
+it wrong and LTspice either errors ("Unknown parameter") or silently
+produces nonsense. When using `sim_ltspice.symbols.parse_asy`, the
+`.asy`'s `SpiceOrder` attribute encodes this — read it first.
+
+## Behavioural sources (`B`)
+
+Analog function of other nodes:
+
+```spice
+B1 out 0 V=V(in)*V(in)         ; output = V(in)^2
+B2 out 0 I=I(R1)*10            ; current = 10 × I(R1)
+```
+
+Useful for idealized op-amps, custom sensors, control laws.
+
+## Syntax rules that trip agents
+
+1. **First line is the title — always ignored.** Your first element
+   declaration must start on line 2. `V1 in 0 1` on line 1 is treated
+   as a comment.
+2. **Continuation with `+`.** A `+` at column 0 means the line
+   continues the previous element. Our parser handles this; your hand-
+   written netlists usually don't need it.
+3. **Case-insensitive identifiers.** `R1`, `r1`, `R_load`, `r_LOAD`
+   all refer to the same instance. LTspice preserves the original
+   spelling in output.
+4. **Numeric suffixes.** `1k` = 1 000, `1meg` = 1 × 10⁶ (note: `meg`,
+   not `M` — `M` = milli). `1u` = 1e-6. `1f` = 1e-15.
+5. **No quoting.** SPICE has no string-literal syntax; paths and model
+   names are written bare. Spaces in a path are a hard error.
+
+## See also
+
+- `spice_directives.md` — for `.tran`, `.ac`, `.meas`, `.param`, etc.
+- LTspice Help → "Circuit Element Quick Reference" for the complete
+  authoritative list (on Windows: `%LOCALAPPDATA%\Programs\ADI\LTspice\LTspiceHelp\cirquick.html`).

--- a/ltspice/base/reference/platform_dispatch.md
+++ b/ltspice/base/reference/platform_dispatch.md
@@ -1,0 +1,60 @@
+# Platform dispatch — when to use `--host <win1>`
+
+LTspice has two very different install flavors. Pick the right one for
+what you're doing.
+
+## macOS native (LTspice 17.x)
+
+- ✅ `.net` / `.cir` / `.sp` batch runs — fully supported
+- ✅ `.meas` result extraction — fully supported
+- 🟡 `.asc` input — only when schematic is flat + uses shipped library
+  symbols (sim-ltspice's native asc2net handles these)
+- ❌ Hierarchical `.asc`, custom `.subckt` symbols, `-ascii` raw
+  output, `-netlist` schematic→netlist conversion
+
+If `sim run my.asc --solver ltspice` raises `MacOSCannotFlatten`, your
+schematic is hitting one of the ❌ cases above. Route via win1.
+
+## Windows (LTspice 26.x)
+
+- ✅ Everything. `.asc` input with any topology, `-netlist` pass,
+  `-ascii` raw output, full batch surface.
+- Reach it via `sim --host 100.90.110.79` (tailscale IP; see
+  `../sim-cli/SKILL.md` for the HTTP dispatch model).
+
+## Decision tree
+
+```
+.net input?  ────────────────→ Run local. macOS and Windows both fine.
+
+.asc input + flat + library-only? ──→ Run local on Mac (native asc2net).
+                                      Or on Win1 (uses LTspice -netlist).
+
+.asc input + hierarchy / custom lib? ──→ Route via sim --host 100.90.110.79.
+
+Need .raw in ASCII format? ──→ Win1 only (`-ascii` flag unsupported on Mac).
+
+Need schematic→netlist conversion WITHOUT simulating?
+                               ──→ Win1 only (`-netlist` is the command).
+```
+
+## One command covers both
+
+```bash
+# Auto-detect: local if possible, remote win1 otherwise.
+# sim-cli handles the routing based on the input's requirements.
+sim --host 100.90.110.79 run design.asc --solver ltspice
+```
+
+You can always use `--host 100.90.110.79` even for cases that would
+work locally — it's the universal answer. Costs a round-trip; gains
+feature parity.
+
+## Why the difference?
+
+LTspice's macOS native build is a direct port with a minimal command
+surface (`-b` only). The full CLI — rotation of `-b` / `-Run` / `-netlist`
+/ `-ascii` / `-FastAccess` / `-encrypt` / `-sync` — only exists on
+Windows and in wine. This isn't a bug; Analog Devices explicitly
+scoped the Mac native build as "batch-run-a-netlist and nothing
+else." For full scripting, wine on macOS or a Windows host is the path.

--- a/ltspice/base/reference/result_extraction.md
+++ b/ltspice/base/reference/result_extraction.md
@@ -1,0 +1,148 @@
+# Result extraction
+
+Three layers of getting numbers out of an LTspice run. Pick the
+**shallowest** layer that answers your question — going deeper is
+slower, and `.meas` is the only layer that stays stable across LTspice
+versions.
+
+| Layer | What it returns | When to use | sim-cli path |
+|---|---|---|---|
+| `.meas` (in netlist) | Named scalar(s) per analysis | Acceptance criteria, spec checks | `sim logs last --field measures` |
+| `RawRead` cursors | Scalar queries on traces (`max`, `min`, `mean`, `rms`, `sample_at`) | Ad-hoc values you didn't pre-declare | `sim_ltspice.RawRead(raw_path).max("V(out)")` |
+| `RawRead` arrays | Full NumPy arrays per trace | Plotting, custom math, exporting | `RawRead(raw_path).trace("V(out)")` |
+
+---
+
+## Layer 1 — `.meas` (always try this first)
+
+`.meas` statements live in the netlist and LTspice evaluates them at
+the end of the run. Results flow into the `.log` and sim-cli's driver
+surfaces them as structured JSON:
+
+```bash
+sim run rlc_ac.net --solver ltspice
+sim logs last --field measures --json
+# → {"fr":      {"expr": "WHEN Vdb(out)=MAX(Vdb(out))", "value": 5023.4, "from": 0, "to": 0},
+#    "peakdb":  {"expr": "MAX Vdb(out)",                "value":   19.2, "from": 0, "to": 0},
+#    "q_est":   {"expr": "FIND Vdb(out) AT 5.03k",      "value":   19.1, "from": 0, "to": 0}}
+```
+
+Under `.step`, each measure's `value` becomes a **list** indexed by
+step number. Don't assume scalar.
+
+### When to prefer `.meas`
+
+- The acceptance criterion is known upfront.
+- You want the result in the `.log` for a human to eyeball too.
+- You need the result usable from *any* sim-cli call — no Python needed.
+
+### When `.meas` isn't enough
+
+- Exploratory: you don't yet know *what* to measure.
+- Cross-trace math (`V(a) / V(b)` at a specific frequency) —
+  expressible in `.meas` but much more readable in Python.
+- You need the whole waveform, not a scalar — fall through to Layer 2 / 3.
+
+---
+
+## Layer 2 — `RawRead` cursor queries
+
+When the number isn't `.meas`-able (yet) and you want a scalar, open
+the `.raw` and ask it. Every method takes a trace name and returns a
+Python scalar — complex on AC analyses, real elsewhere.
+
+```python
+from sim_ltspice import RawRead
+
+rr = RawRead("sim.raw")
+
+rr.max("V(out)")            # 3.142  (scalar)  — magnitude for complex
+rr.min("I(R1)")             # -0.00198
+rr.mean("V(out)")            # 1.57   — arithmetic mean
+rr.rms("V(out)")             # 2.22   — sqrt(mean(|x|²))
+rr.sample_at("V(out)", 2e-3) # linear-interpolated value at t=2 ms
+```
+
+### `.eval(expr)` — arithmetic over traces
+
+For "the number at the same x across two traces" questions:
+
+```python
+rr.eval("V(out) / V(in)")            # complex array on AC; real on TRAN
+rr.eval("V(out) - V(in)")
+rr.eval("Vdb(out) - Vdb(in)")        # not allowed — Vdb is a function call
+```
+
+Accepted: `V(node)`, `I(device)`, numeric literals, `+ - * / ** %` and
+unary `-`. Disallowed: function calls, attribute access, subscripting,
+comparisons — all raise `InvalidExpression`.
+
+For log-domain math, take the expression result and do `20*log10(abs(...))`
+in NumPy:
+
+```python
+import numpy as np
+H = rr.eval("V(out) / V(in)")        # complex transfer function
+Hdb = 20 * np.log10(np.abs(H))       # magnitude in dB
+```
+
+### Stepped sweeps
+
+`rr.sample_at()` raises on stepped sweeps because the axis is
+non-monotonic across concatenated steps. For stepped runs, use `.meas`
+(Layer 1) or walk the `.raw` in arrays (Layer 3) and slice by step.
+
+---
+
+## Layer 3 — Whole-trace arrays
+
+When you need the waveform itself (plotting, FFT, custom filter,
+external tool handoff):
+
+```python
+rr = RawRead("sim.raw")
+
+t    = rr.axis                       # np.ndarray — time on .tran, freq on .ac
+vout = rr.trace("V(out)")            # np.ndarray — same length as axis
+```
+
+### Export paths
+
+```python
+rr.to_csv("sim.csv")                 # one column per trace; axis first
+                                     # complex → "<name>.re" + "<name>.im" pairs
+
+df = rr.to_dataframe()               # requires sim-ltspice[dataframe]
+                                     # axis is index, one column per non-axis trace
+df["V(out)"].plot()                  # standard pandas from here
+```
+
+Handy for handing a simulation off to a human reviewer — CSV opens in
+Excel, DataFrame plots in Jupyter.
+
+### Trace names
+
+```python
+rr.trace_names()                     # ['time', 'V(in)', 'V(out)', 'I(R1)']
+```
+
+Prefixes: `V(...)` for node voltages, `I(...)` for device currents,
+`time`/`frequency` for the axis (automatically handled by `rr.axis`).
+
+---
+
+## Decision cheat sheet
+
+```
+Do you already know what number you want?
+├── Yes → Layer 1 (.meas)
+└── No  → Open .raw
+         ├── Scalar answer (peak, RMS, value at x)? → Layer 2 (cursors)
+         ├── Cross-trace arithmetic at matched x?   → Layer 2 (rr.eval)
+         └── Whole waveform (plot, FFT, handoff)?   → Layer 3 (arrays / to_csv / to_dataframe)
+```
+
+## Comparing two runs
+
+For regression / A-B comparison, don't roll your own diff — use
+`sim_ltspice.diff`. See `base/workflows/regression_diff.md`.

--- a/ltspice/base/reference/spice_directives.md
+++ b/ltspice/base/reference/spice_directives.md
@@ -39,6 +39,43 @@ Results appear in the `.log` and in `sim logs last --field measures`:
 {"vout_pk": {"expr": "MAX(V(out))", "value": 4.97, "from": 0, "to": 0.005}}
 ```
 
+### AC `.meas` quirk: prefer `mag(...)` over `db(...)` / `Vdb(...)`
+
+In AC analysis, `FIND db(V(out)) AT <freq>` can return wildly wrong
+values (observed −17 dB vs. actual −0.09 dB on a flat-band probe at
+5 kHz of a series-RLC band-pass centered at 5.03 kHz). The same
+measurement written with `mag(V(out))` returns the expected magnitude
+and `20*log10(mag)` matches the displayed `db()` trace.
+
+Mechanism (empirical, not documented by Analog Devices): `db(...)`
+inside a `.meas FIND ... AT` expression interpolates across the decade
+grid on the log-scale result of `db()` instead of the linear magnitude,
+which amplifies the interpolation error near a peak. `mag(...)` uses
+the underlying complex sample and is stable.
+
+**Rule of thumb.** When writing AC `.meas` directives, prefer:
+
+```
+.meas AC gain_5k  FIND mag(V(out)) AT 5.03k          ; stable (linear)
+```
+
+over:
+
+```
+.meas AC gain_5k  FIND db(V(out))  AT 5.03k          ; can be wildly wrong
+.meas AC gain_5k  FIND Vdb(out)    AT 5.03k          ; same issue
+```
+
+For thresholded corner frequencies (WHEN form), both work, because
+LTspice searches for the crossing on the sample grid directly:
+
+```
+.meas AC fc_lo WHEN db(V(out)) = -3                  ; OK
+```
+
+If you need dB in the result, capture linear magnitude and convert
+post-hoc: `value_db = 20 * log10(abs(m.value))`.
+
 ## Parameters and sweeps
 
 ```

--- a/ltspice/base/reference/spice_directives.md
+++ b/ltspice/base/reference/spice_directives.md
@@ -1,0 +1,97 @@
+# SPICE directives — LTspice cheat sheet
+
+All directives start with `.` and live anywhere in the netlist (but
+convention is near the bottom, after the element list). Case-insensitive.
+
+## Analysis (you must have at least one)
+
+| Directive | Purpose | Typical form |
+|---|---|---|
+| `.tran` | Time-domain transient | `.tran 5m` — run for 5 ms with auto timestep |
+| `.tran <tstep> <tstop>` | With explicit step | `.tran 1u 5m` — 1 µs step, 5 ms end |
+| `.ac dec N fstart fstop` | Small-signal AC sweep | `.ac dec 20 10 100k` — 20 points/decade, 10 Hz to 100 kHz |
+| `.dc Vsrc start stop step` | DC sweep | `.dc V1 0 5 0.1` |
+| `.op` | Quiescent operating point | `.op` |
+| `.noise V(out) Vsrc dec N fstart fstop` | Noise analysis | `.noise V(out) V1 dec 20 10 100k` |
+| `.tf V(out) Vsrc` | Small-signal transfer function | `.tf V(out) V1` |
+| `.four freq V(out)` | Fourier analysis on transient | `.four 1k V(out)` (must follow `.tran`) |
+
+## Measurements (`.meas` / `.measure`)
+
+Single value:
+
+```
+.meas TRAN vout_pk  MAX V(out)                              ; peak
+.meas TRAN vout_rms RMS V(out) FROM 1m TO 5m                ; RMS over window
+.meas TRAN t_settle WHEN V(out)=4.95 RISE=1                 ; time to reach 4.95 V on rising edge
+.meas AC   fc       WHEN Vdb(out)=-3                        ; -3 dB corner
+.meas AC   gain     MAX Vdb(out)                            ; peak gain (dB)
+.meas DC   ithresh  FIND I(R1) WHEN V(out)=2.5              ; current at specific output level
+```
+
+Common operators: `MAX`, `MIN`, `AVG`, `RMS`, `PP` (peak-to-peak),
+`INTEG`, `DERIV`, `WHEN`, `FIND`, `FIND...AT`, `PARAM`.
+
+Window modifiers: `FROM <t1> TO <t2>`, `RISE=n`, `FALL=n`, `CROSS=n`.
+
+Results appear in the `.log` and in `sim logs last --field measures`:
+```json
+{"vout_pk": {"expr": "MAX(V(out))", "value": 4.97, "from": 0, "to": 0.005}}
+```
+
+## Parameters and sweeps
+
+```
+.param R_feedback = 10k               ; named constant
+.param R_in = {R_feedback / 10}        ; expression
+
+.step param R_feedback 1k 100k dec 5  ; logarithmic sweep, 5 points/decade
+.step param VIN list 1.8 3.3 5.0 12   ; explicit list
+
+.step dec param C 10p 10n 10           ; equivalent syntax
+```
+
+Each step writes its own section in the `.raw`; `.meas` runs once per
+step; results appear as arrays in the log.
+
+## Initial conditions
+
+```
+.ic V(vcap) = 0                        ; force node voltage at t=0
+.ic I(L1) = 1m                         ; force inductor current
+.nodeset V(x) = 1.2                    ; solver hint for DC op-point
+```
+
+## Models and libraries
+
+```
+.model MyDiode D(Is=1e-14 Rs=0.1 N=1.05)          ; inline model
+.include standard.dio                              ; include a model file
+.lib LTC.lib                                       ; library of subcircuits
+```
+
+## Save / output control
+
+```
+.save V(out) V(in) I(R1)              ; limit what's written to .raw
+.save all                              ; default
+.print TRAN V(out) V(in)               ; legacy text table — prefer .meas
+```
+
+## Options
+
+```
+.options abstol=1e-12 reltol=1e-4 vntol=1e-6
+.options method=trap                   ; or gear / modifiedtrap
+.options nolongnames                   ; PSpice compat
+.options plotwinsize=0                 ; compact raw file (uncompressed)
+```
+
+## End
+
+```
+.end
+```
+
+Ending `.end` is optional for LTspice (unlike classic SPICE3), but
+include it for portability across simulators.

--- a/ltspice/base/snippets/inverting_amp.net
+++ b/ltspice/base/snippets/inverting_amp.net
@@ -1,0 +1,19 @@
+* Inverting amplifier — gain = -R_feedback / R_in
+* Uses shipped LT1001 op-amp via LTspice's bundled LTC.lib
+.lib LTC.lib
+
+.param R_in       = 1k
+.param R_feedback = 10k
+
+V_in  in 0 SINE(0 100m 1k)
+V_pos vcc 0 15
+V_neg vee 0 -15
+
+XU1 0 invnode vcc vee out LT1001      ; vin+ vin- V+ V- out
+R_in        in     invnode  {R_in}
+R_feedback  invnode out      {R_feedback}
+
+.tran 5m
+.meas TRAN vout_pk   MAX V(out)
+.meas TRAN gain      PARAM vout_pk/0.1      ; linear-domain gain
+.end

--- a/ltspice/base/snippets/param_sweep.net
+++ b/ltspice/base/snippets/param_sweep.net
@@ -1,0 +1,13 @@
+* Parameter sweep — vary R_load, measure peak V(out) per step
+* Produces a .raw with one dataset per step; .meas aggregates per step.
+.param R_load = 1k
+
+V1  in 0 PULSE(0 5 0 1u 1u 1m 2m)
+R_source in out 100
+R_load   out 0  {R_load}
+C_load   out 0  10n
+
+.tran 5m
+.step param R_load list 100 330 1k 3.3k 10k
+.meas TRAN vout_peak MAX V(out)
+.end

--- a/ltspice/base/snippets/rc_lowpass.net
+++ b/ltspice/base/snippets/rc_lowpass.net
@@ -1,0 +1,8 @@
+* RC low-pass — 1 kHz -3 dB corner; verify with sim run ... --solver ltspice
+V1  in  0   AC 1 SINE(0 1 1k)
+R1  in  out 1.6k
+C1  out 0   100n
+.ac dec 20 10 100k
+.meas AC fc  WHEN Vdb(out)=-3
+.meas AC gain MAX Vdb(out)
+.end

--- a/ltspice/base/snippets/rlc_ac.net
+++ b/ltspice/base/snippets/rlc_ac.net
@@ -1,0 +1,13 @@
+* Series RLC band-pass — output across R, resonant at fr = 1/(2 pi sqrt(LC)) ≈ 5.03 kHz
+* AC sweep produces complex V(out); use sim_ltspice.RawRead for magnitude/phase.
+V1  in  0   AC 1
+L1  in  a   10m
+C1  a   out 100n
+R1  out 0   50
+.ac dec 50 100 100k
+.meas AC peakmag MAX mag(V(out))
+.meas AC fr      WHEN ph(V(out))=0 CROSS=1
+.meas AC bw_3db_lo  WHEN mag(V(out))=peakmag*0.7071 CROSS=1
+.meas AC bw_3db_hi  WHEN mag(V(out))=peakmag*0.7071 CROSS=LAST
+.meas AC gain_5k FIND mag(V(out)) AT 5.03k
+.end

--- a/ltspice/base/workflows/gui_review_handoff.md
+++ b/ltspice/base/workflows/gui_review_handoff.md
@@ -1,0 +1,194 @@
+# Workflow: GUI review & human-in-the-loop handoff
+
+LTspice is a one-shot batch solver, so unlike Fluent/COMSOL there's no
+live simulation session to drive. But the GUI still matters — for three
+real engineer workflows:
+
+1. **Review handoff** — Python builds an `.asc`; human opens it in LTspice
+   to eyeball the schematic before signing off.
+2. **Waveform view** — after a batch run, spawn the LTspice waveform
+   viewer on the `.raw` so the human can scrub / overlay traces.
+3. **Round-trip edit** — Python proposes an initial design, human tweaks
+   in the GUI and saves, Python reads the modified `.asc` back.
+
+All three share one primitive: **spawn LTspice with a file argument,
+wait for the window to close, continue.** That's it.
+
+## Platform notes
+
+| Capability | macOS 17.x | Windows 26.x |
+|---|---|---|
+| Spawn GUI with `.asc` | `open -a LTspice <file>` or direct `subprocess.Popen([exe, file])` | `subprocess.Popen([exe, file])` |
+| Spawn GUI with `.raw` (waveform viewer) | same | same |
+| `sim.gui.GuiController` / pywinauto introspection | ❌ (`.app`, not pywinauto-driveable) | ✅ |
+| Dismiss dialogs / UIA drilling | not available | `sim.gui` — see the very end of this doc |
+
+If your workflow only needs "open the file + wait for close", the cross-
+platform `subprocess.Popen` + `proc.wait()` path works everywhere and
+that's what this doc uses. Reach for `sim.gui` only when the design
+actually needs window introspection.
+
+> **Note (2026-04-24):** The LTspice driver in sim-cli does not yet
+> inject a `gui` object into the session namespace (unlike Fluent /
+> COMSOL / Flotherm). Until it does, drive the GUI with `sim_ltspice`'s
+> install discovery + standard `subprocess`, as shown below.
+
+## Scenario 1 — review an authored `.asc`
+
+You've programmatically built a schematic. Before passing it downstream,
+you want a human to look at it.
+
+```python
+import subprocess
+from sim_ltspice import (
+    find_ltspice, Netlist, Element, Directive, netlist_to_schematic, write_asc,
+)
+
+# 1. Build the design. `Element` takes (name, nodes, tail);
+#    `Directive` splits into (command, args).
+net = Netlist(
+    title="RC low-pass — review candidate",
+    elements=[
+        Element("V1", ["in", "0"],  "AC 1 SINE(0 1 1k)"),
+        Element("R1", ["in", "out"], "1.6k"),
+        Element("C1", ["out", "0"],  "100n"),
+    ],
+    directives=[Directive(".ac", "dec 20 10 100k")],
+)
+write_asc(netlist_to_schematic(net), "review.asc")
+
+# 2. Hand off to a human. find_ltspice() returns a *list* — empty if
+#    none installed. Use the first hit (normally the only one).
+installs = find_ltspice()
+if not installs:
+    raise RuntimeError("LTspice not installed on this host")
+inst = installs[0]
+
+proc = subprocess.Popen([str(inst.exe), "review.asc"])
+print("LTspice is open — close the window when you're done reviewing.")
+proc.wait()             # blocks until the human closes LTspice
+
+# 3. Re-read — captures any in-GUI save the human made.
+from sim_ltspice import read_asc
+schem = read_asc("review.asc")
+```
+
+On macOS you can also use `subprocess.Popen(["open", "-a", "LTspice",
+"review.asc"])` — the `open` wrapper launches LTspice detached, so
+`proc.wait()` returns immediately. If you need the wait-until-closed
+behavior on macOS, invoke the binary directly (`inst.exe`) so the
+subprocess tracks LTspice.app's lifetime.
+
+## Scenario 2 — show waveforms after a run
+
+```python
+import subprocess
+from sim_ltspice import find_ltspice, run_net
+
+result = run_net("design.net")
+assert result.ok, result.stderr
+
+inst = find_ltspice()[0]
+subprocess.Popen([str(inst.exe), str(result.raw_path)])
+# Don't .wait() — let the waveform viewer stay open while the script
+# continues with the next design.
+```
+
+LTspice opens `.raw` files directly into the waveform viewer; no GUI
+automation needed.
+
+## Scenario 3 — round-trip edit (agent proposes, human finalizes)
+
+```python
+import subprocess
+from pathlib import Path
+from sim_ltspice import (
+    find_ltspice, read_asc, write_asc, schematic_to_netlist,
+    write_net, run_net, diff,
+)
+
+asc = Path("candidate.asc")
+write_asc(initial_schematic(), asc)   # agent-supplied builder
+
+# Compute a hash so we can detect whether the human actually edited.
+before_mtime = asc.stat().st_mtime
+
+proc = subprocess.Popen([str(find_ltspice()[0].exe), str(asc)])
+proc.wait()
+
+after = read_asc(asc)
+edited = asc.stat().st_mtime > before_mtime
+
+if not edited:
+    print("Human didn't touch it — accepting agent's version.")
+else:
+    print("Human edited; re-simulating and diffing vs baseline.")
+    net = schematic_to_netlist(after)
+    write_net(net, "candidate.net")
+    new_run = run_net("candidate.net")
+
+    # Was there a baseline? diff to show the cost of the human's edit.
+    if Path("baseline.raw").exists():
+        result = diff("baseline.raw", new_run.raw_path)
+        if not result.ok:
+            for t in result.mismatched[:5]:
+                print(f"  {t.name}: max_abs={t.max_abs:.3e}")
+```
+
+## Scenario 4 — programmatic build → GUI review → acceptance loop
+
+Combine with `.meas`-based acceptance:
+
+```python
+import subprocess
+from sim_ltspice import find_ltspice, run_net
+
+# Agent proposes, human reviews, agent runs, verifies acceptance.
+subprocess.Popen([str(find_ltspice()[0].exe), "design.asc"]).wait()
+r = run_net("design.net")
+fc = r.log.measures["fc"].value           # Measure dataclass → .value / .expr
+assert 950 <= fc <= 1050, f"fc drifted: {fc}"
+```
+
+The human's job is *review*, not verification. Acceptance still comes
+from `.meas` — see `meas_based_acceptance.md`.
+
+## When you do need `sim.gui` (Windows, future)
+
+Edge cases that need pywinauto-level control:
+
+- **Dismiss a blocking "Simulation errors" dialog** that LTspice
+  sometimes pops even under `-b` on Windows.
+- **Check for an open waveform plot** of a specific `.raw` before
+  spawning a second one.
+- **Activate / screenshot** the LTspice window for a CI artifact.
+
+Once the sim-cli LTspice driver wires `GuiController` into its session
+namespace, the pattern will mirror the other drivers:
+
+```python
+# Future — not yet available on LTspice driver as of 2026-04-24.
+# gui = sim-cli-injected session handle
+dlg = gui.find(title_contains="Simulation errors", timeout_s=2)
+if dlg:
+    dlg.click("OK")
+    gui.wait_until_window_gone("Simulation errors")
+```
+
+Track this in the sim-cli LTspice driver — it's a one-line
+`GuiController(process_name_substrings=("ltspice","LTspice","XVIIx64"))`
+change. Until then, the `subprocess.Popen` pattern above is the canonical
+way to drive the LTspice GUI from an agent, and it covers Scenarios 1–4
+fully.
+
+## Anti-patterns
+
+- **Don't `time.sleep(10)` after `Popen`.** Use `proc.wait()` — it
+  returns the moment the window closes, not on a fixed timer.
+- **Don't parse the `.asc` while LTspice has it open.** LTspice
+  rewrites the file on save; reading mid-session may hit a partial
+  write. Wait for `proc.wait()` first.
+- **Don't open the same `.asc` twice.** LTspice is single-instance per
+  file on Windows; the second spawn focuses the existing window silently.
+- **Don't assume the human edited.** Check `mtime` — the "save &
+  close" and "just close" paths look the same from Python otherwise.

--- a/ltspice/base/workflows/meas_based_acceptance.md
+++ b/ltspice/base/workflows/meas_based_acceptance.md
@@ -1,0 +1,71 @@
+# Workflow: `.meas`-based acceptance
+
+Pattern for any LTspice design with a numeric acceptance criterion.
+Works today (netlist only); extends to `.asc` once `sim-ltspice` v0.1
+ships.
+
+## 1. State the acceptance in words first
+
+Example: *"The RC low-pass must have its -3 dB corner at 1 kHz ± 5%."*
+
+Derived measurables:
+- `fc` — the frequency where `Vdb(out) = -3`. Must be in [950, 1050].
+- `gain_dc` — low-frequency gain. Must be in [-0.1, 0]  dB (passive filter, no gain).
+
+## 2. Translate to `.meas` in the netlist
+
+```spice
+* RC low-pass — 1 kHz -3 dB corner
+V1 in 0 AC 1
+R1 in out {R}
+C1 out 0 {C}
+
+.param R = 1.6k
+.param C = 100n
+
+.ac dec 20 10 100k
+.meas AC fc       WHEN Vdb(out)=-3
+.meas AC gain_dc  FIND Vdb(out) AT 10
+.end
+```
+
+One `.meas` per acceptance measurable. Named using snake_case matching
+the acceptance statement.
+
+## 3. Run
+
+```bash
+sim run design.net --solver ltspice
+sim logs last --field measures
+# → {"fc": {..., "value": 995.2}, "gain_dc": {..., "value": -0.008}}
+```
+
+## 4. Verify in Python
+
+```python
+import json, subprocess
+
+out = subprocess.check_output(
+    ["sim", "logs", "last", "--field", "measures", "--json"],
+    text=True,
+)
+m = json.loads(out)
+
+assert 950 <= m["fc"]["value"] <= 1050, m["fc"]
+assert -0.1 <= m["gain_dc"]["value"] <= 0, m["gain_dc"]
+```
+
+## 5. On failure, mutate one knob at a time
+
+If `fc` is wrong, don't change `R` and `C` together. Drop `C` to a
+reference value (100n), sweep `R` with `.step param R 1k 2k lin 10`,
+`sim run` once, and read the array-valued `fc` back from
+`sim logs last --field measures`. Then pick the `R` whose `fc` is
+closest to 1 kHz and lock that in.
+
+## 6. If acceptance is ambiguous
+
+Ask the human for a tolerance before writing `.meas`. Don't guess:
+"within 5%" differs from "within 2%" and from "close enough to look
+right in a plot." The whole point of `.meas` + acceptance is to make
+this pass/fail deterministic.

--- a/ltspice/base/workflows/param_sweep_postprocess.md
+++ b/ltspice/base/workflows/param_sweep_postprocess.md
@@ -1,0 +1,166 @@
+# Workflow: parameter sweep → post-processing
+
+`.step param` gives you *n* sweep points in one batch run. Three
+post-processing options, from cheapest to richest:
+
+1. `.meas` aggregator — scalar per step, surfaced as a list via
+   `sim logs last --field measures`.
+2. `RawRead.to_dataframe()` — full traces for every step, as a
+   `pandas.DataFrame` indexed by the sweep axis.
+3. `RawRead` arrays + NumPy — custom per-step math.
+
+Reach for #1 whenever the answer is "one number per step"; #2/#3 when
+you want the whole waveform or custom aggregations the `.meas` syntax
+can't express.
+
+## The sweep netlist
+
+Example — sweep a load resistor across five decade points:
+
+```spice
+* Parameter sweep — vary R_load, measure peak V(out) per step
+.param R_load = 1k
+
+V1  in 0 PULSE(0 5 0 1u 1u 1m 2m)
+R_source in out 100
+R_load   out 0  {R_load}
+C_load   out 0  10n
+
+.tran 5m
+.step param R_load list 100 330 1k 3.3k 10k
+.meas TRAN vout_peak MAX V(out)
+.end
+```
+
+See `base/snippets/param_sweep.net` for a copy-paste version.
+
+## Pattern 1 — `.meas` per step (scalar summary)
+
+```bash
+sim run param_sweep.net --solver ltspice
+sim logs last --field measures --json
+# → {"vout_peak": {"expr": "MAX V(out)",
+#                  "value": [4.91, 4.94, 4.96, 4.98, 4.99],  # list — one per step
+#                  "from": 0, "to": 0.005,
+#                  "step_values": [100, 330, 1000, 3300, 10000]}}
+```
+
+Acceptance in Python:
+
+```python
+import json, subprocess
+m = json.loads(subprocess.check_output(
+    ["sim", "logs", "last", "--field", "measures", "--json"], text=True
+))
+peaks = m["vout_peak"]["value"]
+assert all(p >= 4.9 for p in peaks), f"vout_peak dipped: {peaks}"
+```
+
+When this is enough: acceptance is a scalar bound per step. Maximum,
+minimum, first-crossing, delay, period — all expressible in `.meas`.
+
+## Pattern 2 — DataFrame across steps
+
+When you need the full waveform per step (plotting, FFT, custom
+integration), open the `.raw`:
+
+```python
+from sim_ltspice import RawRead
+
+rr = RawRead("param_sweep.raw")
+df = rr.to_dataframe()       # requires sim-ltspice[dataframe]
+```
+
+`rr.to_dataframe()` returns every concatenated step in one frame, with
+the axis as index and one column per trace. **For stepped runs, split
+by the axis-restart boundary** — LTspice concatenates step i+1 right
+after step i, and the axis resets, so `diff(axis) < 0` marks each seam:
+
+```python
+import numpy as np
+
+# Boundaries = indices where the next step starts.
+seams = np.where(np.diff(rr.axis) < 0)[0] + 1
+bounds = [0, *seams.tolist(), len(rr.axis)]
+
+per_step = [df.iloc[a:b] for a, b in zip(bounds[:-1], bounds[1:])]
+
+# Step 2 → load = 1 k (third entry in .step list).
+rload_1k = per_step[2]
+print(rload_1k["V(out)"].max())
+```
+
+`rr.is_stepped` tells you whether a split is even needed. For AC
+sweeps the axis is log-monotonic (not reset), so the seam heuristic
+above doesn't apply — for `.step` + `.ac`, LTspice stores step index
+as a separate axis; inspect `rr.axis` to see which shape you got.
+
+## Pattern 3 — NumPy per-step math
+
+When the post-processing is neither a scalar `.meas` nor "plot it":
+
+```python
+import numpy as np
+from sim_ltspice import RawRead
+
+rr = RawRead("param_sweep.raw")
+t = rr.axis
+v = rr.trace("V(out)")
+i = rr.trace("I(R_load)")
+
+seams = np.where(np.diff(t) < 0)[0] + 1
+bounds = [0, *seams.tolist(), len(t)]
+
+energy_per_step = []
+for start, end in zip(bounds[:-1], bounds[1:]):
+    p = v[start:end] * i[start:end]
+    dt = np.diff(t[start:end])
+    energy_per_step.append(float(np.sum(p[:-1] * dt)))
+
+print(energy_per_step)
+```
+
+If that integral is a recurring check, wrap it in a helper — don't ship
+raw loops in the agent.
+
+## CSV export for handoff
+
+When the consumer is a human or a non-Python tool:
+
+```python
+rr.to_csv("param_sweep.csv")
+# → axis column first, then one column per trace; complex traces
+#   expand into "<name>.re" / "<name>.im" pairs.
+```
+
+Drops straight into Excel, `pandas.read_csv`, or `awk`. Faithful to the
+raw numbers — no interpolation, no resampling.
+
+## Choosing the sweep form
+
+LTspice `.step` has three forms:
+
+```spice
+.step param R 1k 10k lin 5       ; 5 points linearly 1k..10k  (= 1k, 3.25k, ...)
+.step param R 1k 10k dec 10      ; 10 points per decade (log)
+.step param R list 100 330 1k 3.3k 10k   ; explicit list
+```
+
+Use `list` when the acceptance asks for specific points (e.g. "our BOM
+has R = {100, 330, 1k, 3.3k, 10k}"). Use `dec` for frequency-like
+decade sweeps. Use `lin` only when the design is actually linear in the
+parameter — otherwise the endpoints dominate and mid-range info is
+wasted.
+
+## Anti-patterns
+
+- **Don't spawn one `sim run` per step from Python.** `.step` is what
+  LTspice is built for — one run, one `.raw`, N-point analysis. Python
+  loops only when the sweep needs control flow LTspice can't express
+  (e.g. early-stop on acceptance fail).
+- **Don't rely on trace ordering by step-index alone.** The `.raw`
+  concatenates steps contiguously; split by axis-monotonicity seams
+  (see above) to recover per-step slices.
+- **Don't `.to_dataframe()` on multi-GB `.raw`.** Pandas copies into
+  memory; on a laptop, `lin 1000` with dense traces will OOM. Stick to
+  NumPy arrays or decimate.

--- a/ltspice/base/workflows/regression_diff.md
+++ b/ltspice/base/workflows/regression_diff.md
@@ -1,0 +1,149 @@
+# Workflow: two-run regression diff
+
+A headline v0.2 use case: when you change a netlist (swap a model,
+retune an R/C, refactor a subcircuit), you want to know **exactly what
+the waveforms did** — not just whether `.meas` still passes.
+
+`sim_ltspice.diff(a, b)` gives you a per-trace delta report with
+explicit tolerances. Reach for it whenever you'd otherwise be eyeballing
+two `.raw` files side-by-side.
+
+## When to use this instead of `.meas`
+
+| Question | Right tool |
+|---|---|
+| Did the -3 dB corner stay within 5%? | `.meas` in netlist + `sim logs last` |
+| Did *any* trace change more than 1e-4 after the refactor? | `diff(a, b)` |
+| Is the new op-amp model waveform-equivalent to the old one? | `diff(a, b)` |
+| Does CI pass the acceptance criterion? | `.meas` |
+| Does CI reject unintended waveform drift in a refactor PR? | `diff(a, b)` |
+
+Rule of thumb: `.meas` is for **specs**, `diff` is for **regressions**.
+
+## Basic shape
+
+```python
+from sim_ltspice import run_net, diff
+
+r_old = run_net("design_v1.net")
+r_new = run_net("design_v2.net")
+assert r_old.ok and r_new.ok, "runs failed — fix that first"
+
+result = diff(r_old.raw_path, r_new.raw_path, atol=1e-6, rtol=1e-4)
+
+if not result.ok:
+    for t in result.mismatched:
+        print(f"  {t.name}: max_abs={t.max_abs:.3e}  max_rel={t.max_rel:.3e}")
+    raise AssertionError("unintended waveform change")
+```
+
+`DiffResult` is a frozen dataclass. Key fields:
+
+| Field | Type | Meaning |
+|---|---|---|
+| `ok` | `bool` | True iff every included trace is within tolerance AND no set-difference / axis-mismatch |
+| `traces` | `tuple[TraceDiff, ...]` | Per-trace report |
+| `mismatched` | `tuple[TraceDiff, ...]` | Shortcut for `[t for t in traces if not t.within_tol]` |
+| `only_in_a` | `tuple[str, ...]` | Trace names present in `a` but missing in `b` |
+| `only_in_b` | `tuple[str, ...]` | Symmetric |
+| `axis_mismatch` | `str \| None` | Non-None if axes differ (length or values diverge) |
+
+Each `TraceDiff` carries `name`, `max_abs`, `max_rel`, `within_tol`.
+
+## Tolerance model
+
+The gate is the classic NumPy form:
+
+```
+|a - b| <= atol + rtol · |b|
+```
+
+Defaults: `atol=0.0`, `rtol=1e-6`. **Pick both deliberately.**
+
+- `atol` — the "noise floor" where absolute differences are irrelevant.
+  For sub-μV precision on a 5 V rail, `atol=1e-9` is over-strict;
+  `atol=1e-6` is usually plenty.
+- `rtol` — the relative ceiling. `1e-4` = "stay within 0.01% of the
+  reference value."
+
+Complex traces (AC analyses) compare by **magnitude of the difference**:
+`|a - b|`, not `|a| - |b|`. A pure imaginary shift counts.
+
+## Scoping the comparison: `traces=...`
+
+By default every non-axis trace is compared. Restrict to the traces
+you actually care about — much faster on dense `.step` runs and makes
+the failure output readable:
+
+```python
+result = diff(a, b, traces=["V(out)", "I(Rload)"], atol=1e-6)
+```
+
+If a name in `traces=` exists on neither side, it's reported on both
+`only_in_a` and `only_in_b` — that way a typo fails loud instead of
+silently passing.
+
+## Set differences: trace added or removed
+
+If one side has a trace the other lacks (e.g. you renamed a net),
+`only_in_a` / `only_in_b` carry the names and `ok` is False. You can
+still inspect the overlapping traces via `result.traces`.
+
+## Axis mismatch
+
+If the two `.raw` axes differ (different `.tran` stop times, different
+`.ac` sweep ranges, or the axes diverge mid-run):
+
+```python
+if result.axis_mismatch:
+    print(result.axis_mismatch)  # e.g. "axis lengths differ: 1001 vs 501"
+```
+
+Per-trace diffs in this case are `inf` placeholders — the result is
+still a structured object, just not comparable trace-by-trace.
+
+## CI pattern: pinning a golden `.raw`
+
+Cheapest regression guard for a design repo:
+
+```python
+# tests/test_design_regression.py
+from pathlib import Path
+from sim_ltspice import RawRead, run_net, diff
+
+GOLDEN = Path(__file__).parent / "fixtures" / "rc_lowpass.golden.raw"
+
+def test_rc_lowpass_unchanged():
+    r = run_net(Path(__file__).parent / "fixtures" / "rc_lowpass.net")
+    assert r.ok
+    result = diff(GOLDEN, r.raw_path, atol=1e-9, rtol=1e-6)
+    assert result.ok, f"regression: {result.mismatched}"
+```
+
+On first run, commit the produced `.raw` as the golden file. On intended
+changes (new component values, model swap you *meant* to do), update
+the golden in the same commit as the netlist change — the diff is part
+of the PR, not hidden.
+
+Caveats:
+- LTspice `.raw` binary layout is deterministic for a given LTspice
+  version + platform. Across LTspice 17 ↔ 26 you may see float32 ↔
+  float64 drift in transient traces. If CI runs on a different LTspice
+  build than local, use a looser `rtol` (`1e-4`) or keep CI pinned to
+  one LTspice install.
+- Very large `.raw` (> 100 MB) can inflate the git repo. For those,
+  commit a **decimated** golden — run the reference with a coarser
+  `.tran step` — rather than the full resolution.
+
+## Handing off a failing diff
+
+When `result.ok` is False and the human asks "what broke?":
+
+```python
+for t in sorted(result.mismatched, key=lambda x: -x.max_abs)[:5]:
+    print(f"{t.name:30s}  max_abs={t.max_abs:.3e}  max_rel={t.max_rel:.3e}")
+```
+
+Top-5 by absolute delta usually enough to localize. If the bad trace is
+ambiguous (e.g. both `V(mid)` and `V(out)` drifted), overlay the raw
+waveforms in the LTspice GUI — see `gui_review_handoff.md`.


### PR DESCRIPTION
## Summary

First LTspice skill for sim-skills. Authoring guidance for an agent driving LTspice via sim-cli in the one-shot batch model.

## What's in

- `ltspice/SKILL.md` — identity, scope, input classification (.net/.cir/.sp today, .asc once sim-ltspice v0.1 lands), platform capability matrix (macOS 17.x vs Windows 26.x), LTspice-specific hard constraints, required protocol
- `ltspice/base/reference/spice_directives.md` — `.tran` / `.ac` / `.dc` / `.op` / `.noise` / `.meas` / `.step` / `.param` cheat sheet
- `ltspice/base/reference/platform_dispatch.md` — when to use `--host <win1>`, decision tree for `.asc` on Mac vs Windows
- `ltspice/base/snippets/{rc_lowpass,inverting_amp,param_sweep}.net` — ready-to-run examples
- `ltspice/base/workflows/meas_based_acceptance.md` — canonical "acceptance → `.meas` → `sim run` → verify in Python" loop

## sim-cli UX gaps surfaced while drafting

Writing the skill revealed concrete UX issues to fix downstream:

1. **No `.json` flag guidance** — workflow shows `sim logs last --field measures --json` but the current sim-cli may not emit JSON from `--field`. Verify + fix.
2. **No first-class Python consumer** — the workflow examples shell out to `sim logs last`. Once `sim-ltspice` v0.1 ships, agents should be able to `from sim_ltspice import run_net; result = run_net(...)` and get a typed object directly. Driver adapter should route both paths.
3. **`.asc` error surface is ad hoc** — `MacOSCannotFlatten` is named in the skill but not yet defined. Needs to be a real exception in sim-ltspice with a clear message that includes the win1 routing hint.
4. **Windows `.log` encoding divergence** is documented but not explained in driver error messages. If a Win-produced `.log` ever ends up on Mac (e.g., downloaded for review), Python code opening it naively will get garbage — the library should auto-sniff like the driver already does.

## Relation

- Pairs with [sim-ltspice](https://github.com/svd-ai-lab/sim-ltspice) (the Python API library)
- Pairs with the [sim-cli LTspice driver](https://github.com/svd-ai-lab/sim-cli/tree/feat/ltspice-driver) (thin adapter)

## Test plan

- [ ] Trigger the skill from a fresh session with an LTspice prompt; confirm `SKILL.md` loads and points at the right files
- [ ] Run the RC low-pass snippet through `sim run` end-to-end on macOS
- [ ] Run the same snippet through `sim --host <win1>` and verify parity