### PR TITLE
sim-cli: document SSH-vs-desktop session-context foot-gun (Windows)

### DIFF
--- a/sim-cli/SKILL.md
+++ b/sim-cli/SKILL.md
@@ -38,6 +38,40 @@ which one applies:
 
 ---
 
+## Where `sim serve` runs (Windows session-context foot-gun)
+
+If you reach a remote `sim` host via `sim --host <host>` or `SIM_HOST`,
+**how the operator started `sim serve` on that host changes which
+drivers actually work.** This is purely a Windows concern — Linux and
+macOS don't isolate display sessions the same way.
+
+| `sim serve` started from… | Headless drivers (matlab `-batch`, ltspice `-b`, OpenFOAM, all CLI-only) | GUI drivers (Flotherm, COMSOL desktop, Fluent desktop, Mechanical GUI, MATLAB `--ui-mode desktop`) |
+|---|---|---|
+| Logged-in Windows desktop (Windows Terminal / RDP / Task Scheduler with **"run only when user is logged on" + interactive**) | ✅ works | ✅ works — windows are visible, `gui` actuation can find / click / screenshot them |
+| SSH session (`ssh win1` then `sim serve …`) | ✅ works | ❌ silent breakage — windows launch in a non-interactive Windows session with no display surface; `gui` finds zero windows; screenshots come back black; `sim exec`s that touch the GUI hang or no-op |
+
+**What this means for you, the agent:**
+
+- If the host advertises `tools: ["gui"]` on `/connect` (driver in
+  `ui_mode=gui|desktop`) but `gui.find(...)` returns nothing for
+  windows you have strong reason to believe exist, **do not retry**.
+  Surface "the server may have been started from a non-interactive
+  session" as a likely cause and ask the operator to restart `sim
+  serve` from a desktop session. See `escalation.md`.
+- For headless drivers (matlab `-batch` / `.slx` via `sim_shim.run`,
+  OSS solvers, anything that the driver skill explicitly classifies
+  as one-shot batch) the session context does not matter — you can
+  proceed without checking.
+- The agent never starts `sim serve` itself. Server lifecycle is the
+  operator's responsibility; this section exists only so you can
+  diagnose the specific failure mode where the server is up and
+  reachable but GUI ops silently no-op.
+
+See [`gui/SKILL.md`](gui/SKILL.md) for the full GUI actuation API and
+its window-not-found troubleshooting.
+
+---
+
 ## Reference files
 
 | Path | Read when |

--- a/sim-cli/gui/SKILL.md
+++ b/sim-cli/gui/SKILL.md
@@ -209,6 +209,8 @@ Things that commonly make `ok` false:
 | `click` says `no control titled ... in hwnd=...` | the button label in the UI is not what you think | snapshot the window, read `controls[*].name` |
 | `screenshot` returns minimal PNG | window is minimized (pywinauto captures the window rect; min'd windows live at `(-32000, -32000, …)`) | `dlg.activate()` first, then screenshot |
 | `gui.available` is `False` | off-Windows host, or pywinauto not installed | don't use `gui` — fall back to SDK-only path |
+| `list_windows()` returns `[]` even though the solver clearly launched | `sim serve` was started from an SSH / non-interactive Windows session — the GUI exists in a session with no display surface and pywinauto can't see it | ask the operator to restart `sim serve` from a desktop session (RDP, Windows Terminal, or Task Scheduler with **"run only when user is logged on" + interactive**). See [`../SKILL.md` → "Where `sim serve` runs"](../SKILL.md). Do **not** retry. |
+| `screenshot` returns a uniformly black PNG | same as above — non-interactive session has no compositor | same fix |
 
 ## Pitfalls
 
@@ -221,9 +223,16 @@ Things that commonly make `ok` false:
 - **Don't rely on `gui` for SDK-shaped work.** Solver objects (`session`,
   `model`) are always faster and more reliable than UI clicks. `gui` is
   the fallback for the UI-only surface.
-- **Remote servers need a real desktop.** If `sim serve` runs in a
-  Windows service or SSH session 0, pywinauto finds zero windows.
-  Launch `sim serve` from inside an RDP login session.
+- **Remote servers need a real desktop.** If `sim serve` runs from an
+  SSH session, a Windows service, or any non-interactive context, the
+  spawned solver process inherits a session with no display surface.
+  pywinauto then finds zero windows, screenshots come back uniformly
+  black, and `find(...)` silently times out — the server itself is up
+  and reachable, only the GUI half is dead. Restart `sim serve` from a
+  desktop session (Windows Terminal on the console, RDP, or Task
+  Scheduler with "run only when user is logged on" + interactive). See
+  [`../SKILL.md` → "Where `sim serve` runs"](../SKILL.md) for the full
+  driver-by-driver matrix.
 
 ## Related skills
 


### PR DESCRIPTION
## Summary

When the operator starts \`sim serve\` from an SSH session on Windows, the spawned solver process inherits a non-interactive session with no display surface. Headless drivers keep working; GUI drivers silently break — \`gui.list_windows()\` returns \`[]\`, \`find(...)\` times out, screenshots come back uniformly black. The server itself is up and reachable, only the GUI half is dead, with no diagnostic output to tell the agent which case it's in.

This is a Windows session-isolation behavior (Session 0 vs the user's logged-in Session 1), not a sim-cli bug. There is no in-code fix — the operator has to launch \`sim serve\` from a desktop session.

The skills should at least teach an agent to recognize this failure mode and stop retrying.

## Changes

- **\`sim-cli/SKILL.md\`** — new \`## Where \`sim serve\` runs\` section between the execution-model table and the reference-files table. Driver-class × server-launch-context matrix. Agent-facing rules:
  - For headless drivers (matlab \`-batch\`, ltspice \`-b\`, OSS solvers): session context is irrelevant.
  - For GUI drivers: if \`tools: ["gui"]\` is advertised but \`gui.find(...)\` returns nothing for windows that should exist, **don't retry**; surface "the server may have been started from a non-interactive session" and stop.
  - Agent never starts \`sim serve\` itself — server lifecycle is the operator's responsibility.

- **\`sim-cli/gui/SKILL.md\`** — replace the existing one-liner about "remote servers need a real desktop" with an expanded paragraph that names the actual symptoms. Add two rows to the error-handling table:
  - \`list_windows()\` returns \`[]\` even though the solver launched → SSH/non-interactive session
  - \`screenshot\` returns a uniformly black PNG → same cause
  
  Both rows cross-link to the new section in the parent \`SKILL.md\`.

## Why now

Discovered while bootstrapping a sim-cli dev install on a Windows test host: I almost auto-started \`sim serve\` over SSH for a one-shot \`vdp.slx\` demo. That demo would have worked (it's \`matlab -batch\`, headless), masking the fact that the same server would silently break any future GUI-driver demo. The skill now teaches the operator pattern and the agent-side recognition rule.

## Test plan

- [ ] Lint: each new internal link resolves (\`sim-cli/SKILL.md\` → \`gui/SKILL.md\`, \`gui/SKILL.md\` → \`../SKILL.md\` anchor).
- [ ] Frontmatter still parses (no edits there).
- [ ] Section order in \`sim-cli/SKILL.md\` is "How to use → execution-model table → **Where sim serve runs** → Reference files → Hard constraints → Required protocol".

## Followups (separate)

- The matching paragraph in [sim-cli#33](https://github.com/svd-ai-lab/sim-cli/pull/33) (matlab_pkg rename) — when that lands, the \`matlab/base/reference/simulink.md\` path references need a follow-up update PR here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)