### PR TITLE
docs(driver): model-file format reference + inspector pointer

### DIFF
--- a/comsol/SKILL.md
+++ b/comsol/SKILL.md
@@ -40,6 +40,7 @@ single `mph` line (1.2.x). Always read `base/`, then your active
 |---|---|
 | `base/workflows/block_with_hole/` | Steady-state thermal of a heated block with a cylindrical hole. 6 numbered Python steps (`00_create_geometry.py` … `05_plot_temperature.py`). The canonical "smallest end-to-end" reference for this driver. |
 | `base/workflows/surface_mount_package/` | More realistic SMD package thermal model. 6 numbered steps + a `README.md` describing the geometry and acceptance criteria. |
+| `base/reference/mph_file_format.md` | `.mph` is a ZIP archive — internal layout, the three `nodeType` variants (compact/solved/preview), the Global Parameter `T="33"` contract, and the stdlib `mph_inspect` reader. Read this when you need to introspect a `.mph` *without* spinning up `comsolmphserver`. |
 
 Each numbered step is a self-contained snippet you submit via
 `sim exec` after `sim connect --solver comsol`. The snippets use the
@@ -109,6 +110,41 @@ For models that belong to **modules not installed** on the user's host
 (or for browsing by image/category), point the user at
 <https://www.comsol.com/models>. Don't scrape it from the skill — just
 link.
+
+---
+
+## MPH file introspection (stdlib path — no JVM)
+
+For "what's in this `.mph`?" queries — parameters, physics tags,
+nodeType, mesh/solution sizes — prefer the stdlib reader over a live
+JVM:
+
+```python
+from sim.drivers.comsol.lib.mph_inspect import inspect_mph
+summary = inspect_mph(path)   # one-shot dict
+```
+
+`MphArchive` (context manager) and `mph_diff` (two-file delta) are
+also available. `MphFileProbe` is wired into the driver's default
+probe list, so any `.mph` produced by a `sim` run is auto-described
+in `sim inspect last.result` — no extra call needed.
+
+See [`base/reference/mph_file_format.md`](base/reference/mph_file_format.md)
+for the archive layout, the `nodeType` variants, and the Global
+Parameter `T="33"` extraction contract.
+
+---
+
+## Headless `comsolbatch` (not yet implemented)
+
+`comsolbatch.exe -inputfile in.mph -outputfile out.mph -batchlog log.txt`
+is the canonical non-interactive entry point and would let an agent
+smoke-test models without the long-lived `comsolmphserver` setup. The
+driver currently always goes through `comsolmphserver` + JPype.
+Tracked in [sim-proj#51](https://github.com/svd-ai-lab/sim-proj/issues/51)
+/ [sim-cli#47](https://github.com/svd-ai-lab/sim-cli/pull/47); when it
+lands the workflow snippets above will pick up a one-shot path that
+skips GUI actuation entirely.
 
 ---
 

--- a/comsol/SKILL.md
+++ b/comsol/SKILL.md
@@ -120,7 +120,7 @@ nodeType, mesh/solution sizes — prefer the stdlib reader over a live
 JVM:
 
 ```python
-from sim.drivers.comsol.lib.mph_inspect import inspect_mph
+from sim.drivers.comsol.lib import inspect_mph
 summary = inspect_mph(path)   # one-shot dict
 ```
 

--- a/comsol/base/reference/mph_file_format.md
+++ b/comsol/base/reference/mph_file_format.md
@@ -1,0 +1,85 @@
+# `.mph` file format
+
+`.mph` is a **ZIP archive** (magic bytes `50 4b 03 04`). Confirmed across vendor models in `data/`, `demo/builder/`, and `applications/`. You can read it with stdlib `zipfile` — no `comsolmphserver` JVM required.
+
+## Why this matters
+
+When an agent needs to answer "what's in this `.mph`?" — physics tags, parameters, mesh size, whether it's solved — the historical answer was "spin up a 2 GB JVM." For inspection-only queries that's overkill. The stdlib reader (`sim.drivers.comsol.lib.mph_inspect`) collapses these into sub-second calls and is auto-invoked by the driver's diagnostic probes.
+
+## Archive layout
+
+| Entry | Purpose |
+|---|---|
+| `fileversion` | Single line, e.g. `2092:COMSOL 6.4.0.272` — schema number + saved-in version |
+| `modelinfo.xml` | Authoritative metadata (always present): `title`, `description`, `comsolVersion`, `nodeType`, `isRunnable`, `lastComputationTime`, `solvedFileSize`/`compactFileSize` (for previews), `physicsInfo`, `geometryInfo` |
+| `dmodel.xml` | Full model tree (compact + solved). Global Parameters live here — see contract below |
+| `smodel.json` | Alternate JSON model tree (when present). Recursive `{nodes: [...]}` with `apiClass`, `tag`, `type` — easier to walk than `dmodel.xml`. Application Library models include it; pre-6.x re-saves don't |
+| `model.xml` / `fileids.xml` / `clusterignore.xml` / `guimodel.xml` / `auxiliarydatainfo.json` | Smaller manifests |
+| `usedlicenses.txt` | One line per required COMSOL module |
+| `geometry*.mphbin`, `geommanager*.mphbin` | Geometry binary |
+| `mesh*.mphbin`, `xmesh*.mphbin` | Mesh binary |
+| `solution*.mphbin`, `solutionblock*.mphbin`, `solutionstatic*.mphbin` | Solver output (solved nodeType only) |
+| `savepoint*/...` | Solver checkpoints |
+| `modelimage.png`, `modelimage_large.png` | Auto-generated thumbnails |
+| `index.txt` + `preview` (0-byte) | Application Library lazy-load placeholder marker |
+
+## Three `nodeType` values
+
+- **`compact`** — settings only, no mesh or solutions. Re-runnable if `isRunnable=true`.
+- **`solved`** — full mesh + solution blocks. Largest on disk.
+- **`preview`** — Application Library placeholder. Only `modelinfo.xml` + `modelimage.png` present; `index.txt` plus a 0-byte `preview` entry mark it. The full content streams from the gallery on demand.
+
+## Global Parameter contract
+
+Global Parameters in `dmodel.xml`:
+
+```xml
+<ModelParam tag="param">
+  <ModelParamGroupList>
+    <ModelParamGroup tag="default">
+      <param T="33" param="L_chamber" value="0.1" reference="chamber length"/>
+      <param T="33" param="P_in"      value="101325" reference="inlet pressure"/>
+      ...
+```
+
+The `T="33"` siblings inside `<ModelParamGroup>` are the global parameters. **Material-level `T="33"` entries exist deeper in the tree** (under material property nodes) and must be excluded — match by parent-element depth, not by attribute alone.
+
+## `smodel.json` optionality
+
+`smodel.json` is shipped by Application Library models but is **dropped on re-save in pre-6.x COMSOL**. Don't depend on it being present; fall back to `dmodel.xml` for the canonical tree.
+
+## Reading the file
+
+The driver ships `sim.drivers.comsol.lib.mph_inspect` with a stdlib-only API:
+
+```python
+from sim.drivers.comsol.lib.mph_inspect import inspect_mph, MphArchive, mph_diff
+
+# One-shot dict summary
+summary = inspect_mph("model.mph")
+# → {schema, saved_in, node_type, is_runnable, parameters, physics_tags,
+#    study_tags, material_tags, solution_tags, size_breakdown, ...}
+
+# Repeated reads via context manager
+with MphArchive("model.mph") as a:
+    a.parameters()          # dict of {name: {value, reference}}
+    a.physics_tags()        # list[str]
+    a.size_breakdown()      # bytes per category (geometry/mesh/solution/...)
+
+# Diff two models (useful for "did my edits actually change anything?")
+delta = mph_diff("before.mph", "after.mph")
+# → {entries_added, entries_removed, parameters_changed, tags_changed, ...}
+```
+
+`MphFileProbe` is wired into the driver's default probe list, so `sim inspect last.result` after a `.mph`-producing step already includes the summary.
+
+## When not to use this
+
+- Anything that needs to *modify* the model. Use the JPype `model.*` API via a live `comsolmphserver`.
+- Solver runs. Use `comsolmphserver` + JPype, or (when shipped) `comsolbatch` — see [issue #51](https://github.com/svd-ai-lab/sim-proj/issues/51).
+- Geometry/mesh introspection beyond size. The `.mphbin` blocks are opaque without COMSOL's loader.
+
+## References
+
+- `sim-cli` source: [`src/sim/drivers/comsol/lib/mph_inspect.py`](https://github.com/svd-ai-lab/sim-cli/blob/main/src/sim/drivers/comsol/lib/mph_inspect.py)
+- Reverse-engineering write-up: [sim-proj#51](https://github.com/svd-ai-lab/sim-proj/issues/51), [sim-cli#47](https://github.com/svd-ai-lab/sim-cli/pull/47)

--- a/comsol/base/reference/mph_file_format.md
+++ b/comsol/base/reference/mph_file_format.md
@@ -53,7 +53,7 @@ The `T="33"` siblings inside `<ModelParamGroup>` are the global parameters. **Ma
 The driver ships `sim.drivers.comsol.lib.mph_inspect` with a stdlib-only API:
 
 ```python
-from sim.drivers.comsol.lib.mph_inspect import inspect_mph, MphArchive, mph_diff
+from sim.drivers.comsol.lib import inspect_mph, MphArchive, mph_diff
 
 # One-shot dict summary
 summary = inspect_mph("model.mph")

--- a/ltspice/SKILL.md
+++ b/ltspice/SKILL.md
@@ -35,7 +35,7 @@ Python. The file format understanding and platform quirks are the same.
 |---|---|---|
 | `.net` / `.cir` / `.sp` netlist | ✅ today | SPICE3 syntax; first line is title (ignored by solver); must contain at least one analysis directive |
 | `.asc` schematic (flat, library-local) | 🟡 sim-ltspice v0.1+ — on macOS goes through our native asc2net; on Windows/wine goes through LTspice's own `-netlist` | Schematic opens in LTspice GUI for human review |
-| `.asc` schematic (hierarchical or custom lib) | 🟡 Windows / wine only | Requires LTspice's own `-netlist` pass; on macOS raises `MacOSCannotFlatten` with guidance to run `sim --host <win1>` |
+| `.asc` schematic (hierarchical or custom lib) | 🟡 Windows / wine only | Routed through `sim_ltspice.schematic_to_netlist` (the in-process Python flattener, since LTspice 26.0.1's `-netlist` flag is broken). On macOS raises `MacOSCannotFlatten` with guidance to route via a Windows host. |
 | `.raw` / `.log` inputs | ❌ outputs only | Do not pass these to `sim run` |
 
 When you produce a netlist for an agent workflow, **always use `.net`**.
@@ -44,19 +44,31 @@ driver has the fewest edge cases for it.
 
 ## Platform capabilities
 
-| Capability | macOS 17.x native | Windows 26.x | Linux + wine |
-|---|---|---|---|
-| `-b <netlist>` batch run | ✅ | ✅ | ✅ |
-| `-Run -b` | ❌ (ignored) | ✅ | ✅ |
-| `-ascii` raw output | ❌ | ✅ | ✅ |
-| `-netlist <asc>` schematic→netlist | ❌ | ✅ | ✅ |
-| `.asc` direct input to sim run | native asc2net only (flat + library-local) | full | full |
-| `.log` encoding | UTF-16 LE (no BOM) | UTF-8 | UTF-16 LE |
-| `.raw` header encoding | UTF-16 LE | UTF-16 LE | UTF-16 LE |
+| Capability | macOS 17.x native | macOS 26.x native | Windows 26.x | Linux + wine |
+|---|---|---|---|---|
+| `-b <netlist>` batch run | ✅ | ✅ | ✅ | ✅ |
+| `-Run -b` | ❌ (ignored) | ✅ | ✅ | ✅ |
+| `-ascii` raw output | ❌ | ✅ | ✅ | ✅ |
+| `-netlist <asc>` schematic→netlist | ❌ | ✅ † | ⚠️ broken on 26.0.1 | ✅ |
+| `-ini <path>` reproducible-state run | ✅ | ✅ | ✅ | ✅ |
+| `-I<path>` symbol path injection | ✅ | ✅ | ✅ | ✅ |
+| `-FastAccess` `.raw` reformat | ❌ | ✅ | ✅ | ✅ |
+| `-sync` re-extract bundled libs | ❌ | ✅ | ✅ | ✅ |
+| `-version` print version (stderr) | ✅ | ✅ | ✅ | ✅ |
+| `.asc` direct input to sim run | native asc2net only (flat + library-local) | native asc2net | full | full |
+| `.log` encoding | UTF-16 LE (no BOM) | UTF-8 | UTF-8 | UTF-16 LE |
+| `.raw` header encoding | UTF-16 LE | UTF-16 LE | UTF-16 LE | UTF-16 LE |
 
-If you need a feature Windows has and macOS lacks, route through
-`sim --host <win1>`. See `../sim-cli/SKILL.md` for the HTTP dispatch
-model.
+† On macOS 26 the `-netlist` flag works but `sim-ltspice`'s preferred
+path is the in-process `schematic_to_netlist` flattener — no LTspice
+binary touched. Use `-netlist` only when the flattener can't handle a
+hierarchy or custom-symbol case.
+
+If you need a feature macOS lacks (or to dodge the 26.0.1 `-netlist`
+regression), route through `sim --host <windows-host>`. See
+`../sim-cli/SKILL.md` for the HTTP dispatch model. The full
+flag-by-flag table lives in
+[`base/reference/command_line_switches.md`](base/reference/command_line_switches.md).
 
 ## Hard constraints (LTspice-specific)
 
@@ -106,7 +118,11 @@ Always read `base/reference/`, then the relevant snippets + workflows.
 | `base/reference/spice_directives.md` | Cheat sheet: `.tran`, `.ac`, `.dc`, `.op`, `.noise`, `.meas`, `.step`, `.param`, `.ic`, `.nodeset`, `.save` |
 | `base/reference/element_syntax.md` | R / C / L / V / I / D / Q / M / X instance syntax + common model options |
 | `base/reference/result_extraction.md` | Three layers (`.meas` → `RawRead` cursors → arrays) + `eval` / `to_csv` / `to_dataframe`. Read before reaching for `.raw` |
-| `base/reference/platform_dispatch.md` | When to use `--host <win1>`; macOS flat-asc-only constraint |
+| `base/reference/platform_dispatch.md` | When to route to a Windows host; macOS flat-asc-only constraint |
+| `base/reference/command_line_switches.md` | Complete LTspice CLI flag table (16 flags + 2 env vars) — verbatim from the shipped help bundle. Read before constructing any non-default `LTspice.exe` invocation |
+| `base/reference/search_path_resolution.md` | `-I<path>` → ini → schematic dir → `lib/sym/` → `lib/sub/`. The order LTspice walks when resolving symbols and `.lib` includes |
+| `base/reference/log_channel_limits.md` | What `<deck>.log` does and doesn't capture. No GUI session journal — agents must triage hangs vs. solver errors differently |
+| `base/reference/component_models.md` | The 8 generic-model files (`lib/cmp/standard.{bjt,mos,dio,jft,cap,ind,res,bead}`). UTF-16 closed enum used by `Value <model>` references on primitives |
 | `base/snippets/rc_lowpass.net` | Minimal RC transient with one `.meas` |
 | `base/snippets/rlc_ac.net` | Series-RLC band-pass AC sweep — complex `.raw` traces, resonance `.meas` |
 | `base/snippets/inverting_amp.net` | Inverting op-amp with `.include LTC.lib` and gain `.meas` |
@@ -120,14 +136,18 @@ Always read `base/reference/`, then the relevant snippets + workflows.
 ### Documentation lookup
 
 LTspice ships an extensive offline help set on Windows at
-`%LOCALAPPDATA%\Programs\ADI\LTspice\LTspiceHelp\` (~145 HTML files,
-comprehensive SPICE + analysis reference). macOS ships no HTML help
-(the native app has an in-GUI help only).
+`%LOCALAPPDATA%\Programs\ADI\LTspice\LTspiceHelp\` (~738 HTML files
+in 26.x — comprehensive SPICE + analysis reference). macOS 17 ships
+no HTML help (in-GUI help only); macOS 26 has parity with Windows.
 
-For authoritative syntax questions when on Windows:
+The community mirror at [ltwiki.org](https://ltwiki.org/) indexes the
+same content and is searchable from any platform without LTspice
+installed locally.
+
+For authoritative syntax questions on a Windows host:
 
 ```bash
-sim --host 100.90.110.79 exec 'cat "%LOCALAPPDATA%\Programs\ADI\LTspice\LTspiceHelp\<topic>.html"'
+sim --host <windows-host> exec 'cat "%LOCALAPPDATA%\Programs\ADI\LTspice\LTspiceHelp\<topic>.htm"'
 ```
 
 For anyone else, consult the LTspice Users' Guide PDF (search
@@ -164,4 +184,26 @@ convention.
 5. **macOS `.asc` refusal.** If `sim run my.asc --solver ltspice`
    errors with `MacOSCannotFlatten`, either (a) ensure the schematic
    uses only shipped-library symbols and no hierarchy, or (b) route
-   via `sim --host <win1>`.
+   via `sim --host <windows-host>`.
+
+6. **`-netlist` is broken on LTspice 26.0.1 (Windows).** The flag
+   silently hangs — no `.net` written, no exit code, no signal.
+   Don't shell out to `LTspice.exe -netlist`; use
+   `sim_ltspice.schematic_to_netlist` instead. See
+   [`base/reference/command_line_switches.md`](base/reference/command_line_switches.md)
+   for the full regression note.
+
+7. **No GUI session log.** Unlike Flotherm, LTspice writes nothing
+   for GUI events (popups, schematic-load failures, updater
+   dialogs). The only file channel is the per-deck `<deck>.log`,
+   which only covers solver-time errors. For hangs and GUI-only
+   failures, the `sim_ltspice.runner` 300 s timeout is the
+   triage primitive — see
+   [`base/reference/log_channel_limits.md`](base/reference/log_channel_limits.md).
+
+8. **Generic-model lookup is closed.** `Q1 c b e 2N9999` will fail
+   at solve time unless `2N9999` is in `lib/cmp/standard.bjt` or
+   pulled in via `.lib`/`.include`. The 8 `lib/cmp/standard.*`
+   files are the closed enum — see
+   [`base/reference/component_models.md`](base/reference/component_models.md)
+   for offline lint via `ComponentModelCatalog`.

--- a/ltspice/base/reference/command_line_switches.md
+++ b/ltspice/base/reference/command_line_switches.md
@@ -1,0 +1,128 @@
+# LTspice command-line switches
+
+Reproduced verbatim from the help bundle shipped with LTspice 26
+(`LTspiceHelp/commandlineswitches.htm`). This is the **complete**
+documented surface — anything not listed below is not a real flag.
+
+| Flag | Description |
+|---|---|
+| `-alt` | Set solver to **Alternate**. Overridable by the netlist. |
+| `-ascii` | Use ASCII `.raw` files. *"Seriously degrades program performance."* (vendor warning verbatim) |
+| `-b` | Run in **batch mode**. `LTspice.exe -b deck.cir` leaves the data in `deck.raw`. |
+| `-big` / `-max` | Start as a maximized window. (GUI mode.) |
+| `-encrypt` | Encrypt a model library (for 3rd-party model vendors). |
+| `-FastAccess` | Convert a binary `.raw` to **Fast Access** format. |
+| `-FixUpSchematicFonts` / `-FixUpSymbolFonts` | Migrate very-old user files to modern font defaults. |
+| `-ini <path>` | Override the default settings file (`%APPDATA%\LTspice.ini` on Windows, `~/Library/Preferences/LTspice.ini` on macOS). |
+| `-I<path>` | Insert `<path>` into the symbol + file search paths. **Must be the last argument; no space between `-I` and `<path>`.** |
+| `-netlist` | Batch-convert a `.asc` schematic to a `.net` netlist. |
+| `-norm` | Set solver to **Normal**. Overridable by the netlist. |
+| `-PCBnetlist` | Batch-convert `.asc` to PCB-format netlist. |
+| `-Run` | Open the schematic on the cmdline and immediately simulate (no need to press Run). |
+| `-sync` | Update component libraries (re-extracts the bundled `lib.zip` / `examples.zip` to the user-data dir). |
+| `-version` | Print the LTspice version. |
+
+Two environment variables are also documented:
+
+- `PASTE_OMEGA` — when set, paste the UNICODE Ω symbol on the
+  clipboard instead of `"Ohm"`.
+- `CAPITAL_KILO` — when set, use upper-case `K` for *all* metric
+  multipliers, not just those ≥ 1000.
+
+## Three modes the sim-ltspice driver actually uses
+
+```bash
+# Batch-solve a netlist  →  emits sibling .log + .raw
+LTspice.exe -b deck.net                    # Windows / wine
+/Applications/LTspice.app/Contents/MacOS/LTspice -b deck.net  # macOS
+
+# Schematic → netlist (one-shot conversion)
+LTspice.exe -netlist deck.asc              # Windows
+# ⚠️ BROKEN on LTspice 26.0.1 — see "Known regressions" below.
+
+# Reproducible CI run with a fresh ini (no user state leakage)
+LTspice.exe -ini fixtures/clean.ini -b deck.net
+```
+
+## Known regressions and gotchas
+
+### `-netlist` is broken on LTspice 26.0.1 (Windows)
+
+`LTspice.exe -netlist <file.asc>` spawns a windowless process that
+sits at ~0% CPU indefinitely and never writes a `.net`. Reproduced
+against LTspice's own shipped `examples/Educational/MonteCarlo.asc`.
+Workarounds:
+
+1. **Preferred:** use `sim_ltspice.schematic_to_netlist` (the
+   in-process Python flattener). No LTspice binary involved.
+2. Fall back to LTspice XVII (17.2.4) for `.asc` → `.net` if you have
+   it side-by-side.
+
+### `-Run -b` from SSH session 0 hangs indefinitely
+
+LTspice GUI cannot render under `WinSta0\Service`, the session SSH
+processes land in. A `-b` invocation from SSH on Windows hangs (no
+output, never terminates). Workarounds: run `sim serve` from an
+interactive desktop (RDP) session, or invoke from inside an RDP
+shell. The `sim-ltspice` runner has a 300 s default timeout that
+makes this fail-fast rather than hang forever.
+
+### `-Run` is a no-op for `-b`
+
+`-b` already starts simulating immediately. `-Run -b` is the form
+sim-ltspice emits on Windows because some older docs paired them; it
+behaves identically to `-b` alone.
+
+### `-I<path>` ordering trap
+
+`-I` *must be the last argument*, and there is *no space* between
+`-I` and the path. `-I C:\my\syms` is wrong. `-IC:\my\syms` is right.
+Quoting rules apply for paths with spaces: `"-IC:\Program Files\my syms"`.
+
+### `-ini <path>` tradeoff
+
+The `.ini` is INI-with-binary-tail (4 KB-ish). The header is plain
+text (`[Options]`, `UUID=…`, `CaptureAnalytics=…`); the rest is a
+binary blob holding window positions, recent-files, plot defaults,
+search paths. For CI, an empty file works — LTspice repopulates
+defaults on first write.
+
+## Recipes
+
+### Reproducible CI run
+
+```bash
+mkdir -p tests/fixtures/ltspice
+echo "[Options]" > tests/fixtures/ltspice/clean.ini
+echo "CaptureAnalytics=false" >> tests/fixtures/ltspice/clean.ini
+
+LTspice.exe -ini "$(pwd)/tests/fixtures/ltspice/clean.ini" -b deck.net
+```
+
+### Inject a custom symbol path at run time
+
+```bash
+# Last-arg discipline; no space after -I
+LTspice.exe -b deck.net -I"$(pwd)/vendor-symbols"
+```
+
+### Reformat a `.raw` to ASCII (post-hoc)
+
+```bash
+LTspice.exe -b -ascii deck.net   # at simulate time
+# or, if you already have a binary .raw, reformat with -FastAccess (different format)
+```
+
+## What's *not* a flag
+
+Common myths and look-alikes that are not actually CLI flags:
+
+- `-o <path>` / `--output` — does not exist; output filenames derive from the input.
+- `-q` / `-quiet` — does not exist; redirect stdout/stderr to suppress.
+- `-h` / `-help` / `-?` — does not exist (GUI-only app, no stdout help).
+- `-batch` — does not exist; the flag is just `-b`.
+- `--version` (double dash) — does not exist; LTspice's flag is `-version`.
+
+Source of truth lives in the shipped help bundle:
+`%LOCALAPPDATA%\Programs\ADI\LTspice\LTspiceHelp\commandlineswitches.htm`
+on Windows, or its [community mirror at ltwiki.org](https://ltwiki.org/LTspiceHelp/LTspiceHelp/Command_Line_Switches.htm).

--- a/ltspice/base/reference/component_models.md
+++ b/ltspice/base/reference/component_models.md
@@ -1,0 +1,80 @@
+# Generic component model catalogue (`lib/cmp/standard.*`)
+
+LTspice ships **eight** files under `<user-data>/lib/cmp/` —
+one per primitive device kind. Together they define the closed enum
+of generic-model names you can reference via `Value <model-name>` on
+the corresponding primitive symbol (`Q1`, `M1`, `D1`, …). Anything
+not in these files must come from a `.subckt` (in `lib/sub/` or a
+custom `.lib`/`.include`).
+
+## The eight files
+
+| File | Element kind | Models defined | Sample names |
+|---|---|---|---|
+| `standard.bjt` | BJT (`Q…`) | NPN/PNP transistors | `2N2222`, `2N3904`, `2N3906`, `BC547`, `BC557` |
+| `standard.mos` | MOSFET (`M…`) | N/P-channel FETs | `IRF540`, `IRF9540`, `Si4410DY`, `2N7000` |
+| `standard.dio` | Diode (`D…`) | Rectifier / Schottky / Zener | `1N4148`, `1N4007`, `1N5817`, `1N4734` |
+| `standard.jft` | JFET (`J…`) | N/P-channel JFETs | `2N3819`, `2N5460` |
+| `standard.cap` | Capacitor (`C…`) | Non-ideal models with ESR/ESL | E.g. specific caps modelled with parasitics |
+| `standard.ind` | Inductor (`L…`) | Non-ideal models | E.g. core-loss + saturation models |
+| `standard.res` | Resistor (`R…`) | Non-ideal models | E.g. wirewound parasitic Ls |
+| `standard.bead` | Ferrite bead | EMI-suppression beads | Vendor-specific bead models |
+
+## Encoding gotcha — UTF-16 LE
+
+These files are **UTF-16 little-endian** (no BOM in some, BOM in
+others depending on history). Read with `encoding='utf-16'` in
+Python; reading as UTF-8 yields space-padded ASCII gibberish:
+
+```text
+*   C o p y r i g h t   ?   2 0 0 0   ...
+. m o d e l   2 N 2 2 2 2   N P N ( I S = 1 E - 1 4   V A F = 1 0 0
+```
+
+This is a recurring LTspice theme (the macOS `.log` is also UTF-16 LE
+no-BOM). Always sniff before reading.
+
+## Why agents should care
+
+These are the **only** generic-model names LTspice resolves without
+needing a `.subckt` import. If you write:
+
+```spice
+Q1 c b e 2N2222
+```
+
+…and `2N2222` is in `standard.bjt`, the netlist works. If you write
+`Q1 c b e 2N9999` and `2N9999` is not there, LTspice errors at
+solve time with `unknown subckt or model: 2N9999`.
+
+## Offline lint
+
+`sim_ltspice.cmp.ComponentModelCatalog` (forthcoming, see
+[sim-ltspice#TBD](https://github.com/svd-ai-lab/sim-ltspice)) will
+parse all eight files at install-discovery time and expose:
+
+```python
+from sim_ltspice import ComponentModelCatalog
+
+cat = ComponentModelCatalog()
+cat.find("2N2222")           # → ModelDef(name="2N2222", kind="bjt", ...)
+cat.find("2N9999")           # → None
+cat.models("bjt")            # → list of all bjt model names
+cat.kinds()                  # → ("bjt", "mos", "dio", "jft", "cap", "ind", "res", "bead")
+```
+
+The point is to flag bad model references **before** running LTspice
+— catching typos in CI / `sim lint` rather than mid-simulation.
+
+## How it differs from `lib/sub/`
+
+| | `lib/cmp/standard.*` | `lib/sub/*.lib` / `*.sub` |
+|---|---|---|
+| Scope | Generic device models (8 files total) | Vendor-specific parts (~4 891 files) |
+| Format | UTF-16 LE; one `.MODEL` per model | UTF-8/UTF-16 mix; one `.SUBCKT` per part |
+| Referenced via | `Value <model>` on a primitive | `.lib <file>` + `X<inst> nets <subckt>` |
+| Lookup | `ComponentModelCatalog.find()` | `parse_subckt(file)` (parser TBD) |
+
+For board-level simulation you'll mostly use `.lib` / `.include` of
+specific vendor parts. The `cmp` catalogue is for textbook circuits
+and quick discrete-component sketches.

--- a/ltspice/base/reference/log_channel_limits.md
+++ b/ltspice/base/reference/log_channel_limits.md
@@ -1,0 +1,81 @@
+# What `.log` does and doesn't capture
+
+LTspice has **one** observable file channel for run-time errors: the
+per-deck `<deck>.log` written next to the `.net` after a `-b` batch
+run. There is no GUI session journal, no event log, no AppData
+activity record. This is fundamentally different from solvers like
+Flotherm that write a continuous `LogFiles\logFile<timestamp>.xml`
+capturing every GUI action and popup.
+
+## What `.log` captures (i.e. what GUI's "SPICE Error Log" window shows)
+
+These are the errors that the solver itself emits during simulation,
+all of which appear in the `.log`:
+
+- **Solver convergence**: `Time step too small`, `Singular matrix`,
+  `Iteration limit reached`, gmin/source-stepping failures.
+- **Netlist syntax**: `Unknown subckt: XYZ`, `Could not find: V(out)`,
+  `Bad expression`, duplicate node names.
+- **Model loading**: `Could not open: foo.lib`, missing `.MODEL` cards,
+  encrypted-model decryption failures.
+- **Measurement**: `.MEAS` results (the structured outputs we parse),
+  `.MEAS` failures (`measurement failed`, `peakmag did not evaluate`).
+- **Initial conditions**: `.IC` / `.NODESET` warnings.
+- **Run summary**: total elapsed time, solver method, matrix stats.
+
+`sim_ltspice.log.parse_log` surfaces these as
+`LogResult.measures` / `.errors` / `.warnings`.
+
+## What `.log` does NOT capture
+
+These are GUI-side events that never touch the file system:
+
+- **Schematic-load failures**: `Symbol not found in library` when
+  opening an `.asc` interactively. The popup is shown; nothing is
+  logged.
+- **File-version warnings**: "This schematic was saved by a newer
+  version of LTspice…" — modal dialog, no log entry.
+- **Editing dialogs**: "Are you sure you want to discard…", "Place
+  Component" errors, ParseErrors during symbol editing.
+- **Updater popups**: from `updater.exe`, totally separate from
+  `LTspice.exe`.
+- **`-netlist` failure** (LTspice 26.0.1 regression): when
+  `LTspice.exe -netlist <file.asc>` hangs, **no log is written, no
+  exit code, no signal**. The process just sits at 0% CPU.
+
+## Practical implication
+
+The `sim_ltspice.runner` health-check has to use **two strategies**:
+
+| Failure mode | Detection |
+|---|---|
+| Solver error during a batch run | Parse `.log` → `LogResult.errors` |
+| LTspice never produces output (GUI hang, `-netlist` regression, session-0 hang) | Subprocess timeout (default 300 s in `sim_ltspice.runner`) → exit code 124 |
+| Schematic editing / interactive popup | Out of scope for batch driver; use UIA if needed |
+
+`run_net` already handles the first two automatically. There is no
+file-channel equivalent of "tail this log to monitor everything LTspice
+is doing."
+
+## If you want a popup-equivalent observability channel
+
+The closest thing LTspice has: the GUI's `View → SPICE Error Log` is a
+non-modal child window. Its content is written incrementally to
+`<deck>.log` as the solver runs, so tailing the file *during* a long
+batch run gives you live progress. There's no equivalent for events
+*before* the batch starts (schematic-parse stage) or for any GUI-only
+dialog.
+
+## Why this matters for agents
+
+When debugging "LTspice didn't produce output," the diagnostic order is:
+
+1. Did `<deck>.log` get written? If no → process never reached the
+   simulator (likely `-netlist` hang on 26.0.1, or session-0 hang).
+2. If yes, does `LogResult.errors` contain anything? If yes → solver
+   error; read the message.
+3. If `.log` has content but no errors and no `.raw` exists → the
+   netlist was missing an analysis directive (`.tran`, `.ac`, etc.).
+   `sim lint` catches this.
+
+`sim_ltspice` already implements this triage. Don't roll your own.

--- a/ltspice/base/reference/platform_dispatch.md
+++ b/ltspice/base/reference/platform_dispatch.md
@@ -1,25 +1,52 @@
-# Platform dispatch — when to use `--host <win1>`
+# Platform dispatch — when to run remotely on Windows
 
-LTspice has two very different install flavors. Pick the right one for
-what you're doing.
+LTspice has two install flavors with non-trivial capability gaps. Pick
+the right one for what you're doing.
+
+The placeholder `<windows-host>` below stands for whatever Windows
+machine is running `sim serve`. Configure it once via
+`~/.sim/config.toml`:
+
+```toml
+[server]
+host = "<windows-host>"   # an IP, a hostname, or a Tailscale name
+```
+
+…then `sim run …` routes there automatically with no `--host` flag.
+Or pass `--host <windows-host>` per invocation, or set `SIM_HOST`.
 
 ## macOS native (LTspice 17.x)
 
-- ✅ `.net` / `.cir` / `.sp` batch runs — fully supported
-- ✅ `.meas` result extraction — fully supported
-- 🟡 `.asc` input — only when schematic is flat + uses shipped library
-  symbols (sim-ltspice's native asc2net handles these)
+- ✅ `.net` / `.cir` / `.sp` batch runs — fully supported.
+- ✅ `.meas` result extraction — fully supported.
+- 🟡 `.asc` input — only when the schematic is flat + uses
+  shipped-library symbols (`sim-ltspice`'s native `asc2net` flattener
+  handles these without invoking LTspice).
 - ❌ Hierarchical `.asc`, custom `.subckt` symbols, `-ascii` raw
-  output, `-netlist` schematic→netlist conversion
+  output, `-netlist` schematic→netlist conversion.
 
-If `sim run my.asc --solver ltspice` raises `MacOSCannotFlatten`, your
-schematic is hitting one of the ❌ cases above. Route via win1.
+If `sim run my.asc --solver ltspice` raises `MacOSCannotFlatten`,
+your schematic is hitting one of the ❌ cases above. Route via a
+Windows host.
+
+## macOS native (LTspice 26.x)
+
+LTspice 26.0.0 was the first parallel macOS+Windows release (Dec 2025).
+Capability parity with Windows is greater than 17.x, but the same
+flat-asc-only constraint **applies in `sim-ltspice`'s flattener**
+because the library deliberately doesn't shell out to LTspice for
+authoring (the Python flattener handles flat + library-local
+schematics without touching LTspice). For hierarchical or
+custom-symbol `.asc` the answer is still: route via a Windows host.
 
 ## Windows (LTspice 26.x)
 
-- ✅ Everything. `.asc` input with any topology, `-netlist` pass,
-  `-ascii` raw output, full batch surface.
-- Reach it via `sim --host 100.90.110.79` (tailscale IP; see
+- ✅ Everything. `.asc` input with any topology, `-ascii` raw output,
+  full batch surface.
+- ⚠️ `-netlist` is **broken on 26.0.1** — see
+  [`command_line_switches.md`](command_line_switches.md) "Known
+  regressions". Use the in-process flattener instead.
+- Reach it via `sim --host <windows-host>` (configurable; see
   `../sim-cli/SKILL.md` for the HTTP dispatch model).
 
 ## Decision tree
@@ -28,33 +55,36 @@ schematic is hitting one of the ❌ cases above. Route via win1.
 .net input?  ────────────────→ Run local. macOS and Windows both fine.
 
 .asc input + flat + library-only? ──→ Run local on Mac (native asc2net).
-                                      Or on Win1 (uses LTspice -netlist).
+                                      Or on a Windows host.
 
-.asc input + hierarchy / custom lib? ──→ Route via sim --host 100.90.110.79.
+.asc input + hierarchy / custom lib? ──→ Route via sim --host <windows-host>.
 
-Need .raw in ASCII format? ──→ Win1 only (`-ascii` flag unsupported on Mac).
+Need .raw in ASCII format? ──→ Windows only (`-ascii` flag).
 
 Need schematic→netlist conversion WITHOUT simulating?
-                               ──→ Win1 only (`-netlist` is the command).
+                               ──→ Use sim_ltspice.schematic_to_netlist
+                                   (the broken `-netlist` flag is no
+                                   longer the recommended path).
 ```
 
 ## One command covers both
 
 ```bash
-# Auto-detect: local if possible, remote win1 otherwise.
+# Auto-detect: local if possible, remote Windows host otherwise.
 # sim-cli handles the routing based on the input's requirements.
-sim --host 100.90.110.79 run design.asc --solver ltspice
-```
+sim run design.asc --solver ltspice
 
-You can always use `--host 100.90.110.79` even for cases that would
-work locally — it's the universal answer. Costs a round-trip; gains
-feature parity.
+# Force-remote (always go to Windows even when local would work)
+sim --host <windows-host> run design.asc --solver ltspice
+```
 
 ## Why the difference?
 
-LTspice's macOS native build is a direct port with a minimal command
-surface (`-b` only). The full CLI — rotation of `-b` / `-Run` / `-netlist`
-/ `-ascii` / `-FastAccess` / `-encrypt` / `-sync` — only exists on
-Windows and in wine. This isn't a bug; Analog Devices explicitly
-scoped the Mac native build as "batch-run-a-netlist and nothing
-else." For full scripting, wine on macOS or a Windows host is the path.
+LTspice's macOS 17 native build was a direct port with a minimal
+command surface (`-b` only). The full CLI — `-b` / `-Run` / `-netlist`
+/ `-ascii` / `-FastAccess` / `-encrypt` / `-sync` — only existed on
+Windows and in wine. LTspice 26 narrowed the gap considerably (macOS
+26 supports more flags), but `sim-ltspice`'s default routing rules
+still favor the flatten-locally / solve-on-Windows split for
+hierarchical `.asc` because the Python flattener is the most reliable
+authoring path on either platform.

--- a/ltspice/base/reference/search_path_resolution.md
+++ b/ltspice/base/reference/search_path_resolution.md
@@ -1,0 +1,96 @@
+# Symbol & include search path resolution
+
+When LTspice (or `sim-ltspice`) tries to resolve `<symbol>` references
+in a `.asc` or `.lib` / `.include` directives in a `.net`, it walks
+search paths in a deterministic order. Knowing this order is the
+fastest way to debug "symbol not found" / "library not found" errors.
+
+## Resolution order
+
+```
+1. -I<path> from CLI               # injected at invoke time, takes precedence
+2. Settings → Search Paths         # persisted in LTspice.ini
+3. <schematic-dir>/                # the directory containing the .asc being opened
+4. <user-data>/lib/sym/  (recursive)
+5. <user-data>/lib/sub/
+```
+
+`<user-data>` is:
+- Windows: `%LOCALAPPDATA%\LTspice\`
+- macOS: `~/Library/Application Support/LTspice/`
+
+`<install-root>/lib/` (under `Programs\ADI\LTspice\`) is **not** on
+the search path — the bundled `lib.zip` is unzipped to the user-data
+dir on first launch and re-extracted by `LTspice.exe -sync`.
+
+## sim-ltspice extensions
+
+`sim_ltspice.symbols.SymbolCatalog` honours an additional env var on
+top of the LTspice-native order:
+
+```
+$LTSPICE_SYM_PATH        # colon-separated (POSIX) or semicolon (Windows)
+```
+
+This lets you point a single environment at a project-local symbol
+dir without modifying `LTspice.ini`. Catalog discovery is:
+
+```
+$LTSPICE_SYM_PATH        ─→ first
+<platform default lib/sym>  ─→ fallback
+```
+
+## Common failure modes
+
+### "Could not find symbol: XYZ" in `.asc`
+
+Symbol resolution failed. Check, in order:
+
+1. **Typo?** `SymbolCatalog().find("XYZ")` returns `None` if the name
+   is wrong. Use `.names()` to fuzzy-match.
+2. **Wrong category?** Top-level `lib/sym/*.asy` (54 primitives:
+   `res`, `cap`, `ind`, `voltage`, `nmos`, `npn`, …) vs. nested
+   `lib/sym/PowerProducts/LT3045.asy` (2 755 part-specific symbols).
+   The lookup is recursive, so naming the symbol is enough — but if
+   two categories collide on a name, the first match wins.
+3. **Custom symbol not on path?** Drop the `.asy` next to your `.asc`,
+   or pass `-I<dir>` at invoke time, or set `$LTSPICE_SYM_PATH`.
+4. **Stale install?** `LTspice.exe -sync` re-extracts the bundled
+   `lib.zip` if the user-data dir was nuked.
+
+### "Could not open: foo.lib"
+
+Library resolution failed. Most common cause: relative path in a
+`.include` / `.lib` directive that resolves against the *netlist's*
+directory, not the cwd. Two fixes:
+
+- Use an absolute path: `.lib "C:\path\to\foo.lib"`
+- Use `<schematic-dir>/`-relative: `.lib "./vendor/foo.lib"` and
+  ensure the file sits next to the `.net`.
+
+## Symbol library shape (LTspice 26)
+
+`<user-data>/lib/sym/` holds **6 571 `.asy` symbols** organized as:
+
+| Subtree | Count | Purpose |
+|---|---:|---|
+| `lib/sym/` (top-level) | 54 | Generic primitives — `res`, `cap`, `ind`, `voltage`, `nmos`, `npn`, etc. |
+| `lib/sym/PowerProducts/` | 2 755 | Vendor switching regulators, LDOs, motor drivers |
+| `lib/sym/Contrib/` | 2 423 | Community-contributed symbols |
+| `lib/sym/OpAmps/` | 759 | Op-amp catalogue |
+| `lib/sym/SpecialFunctions/` | 196 | Behavioural blocks, controllers |
+| `lib/sym/Switches/` | 173 | Voltage/current-controlled switches |
+| `lib/sym/References/` | 76 | Voltage references |
+| `lib/sym/ADC/` | 60 | A/D converters |
+| `lib/sym/Comparators/` | 51 | Comparators |
+| `lib/sym/Misc/` | 41 | Miscellaneous |
+| `lib/sym/DAC/` | 39 | D/A converters |
+| `lib/sym/FilterProducts/` | 26 | Filter parts |
+| `lib/sym/Digital/` | 17 | Digital gates |
+| `lib/sym/Optos/` | 16 | Opto-isolators |
+| `lib/sym/CurrentMonitors/` | 2 | Current sense |
+| `lib/sym/Transceivers/` | 2 | Transceivers |
+
+`lib/sub/` ships **2 798 `.sub` files + 2 093 `.lib` files** —
+SPICE-text sub-circuit definitions for vendor parts, referenced via
+`.lib` / `.include` rather than as schematic symbols.


### PR DESCRIPTION
## Summary
- New `driver/base/reference/model_file_format.md` distilling the model-file-as-ZIP findings (archive layout, three nodeType variants, Global Parameter `T="33"` contract, sidecar JSON optionality).
- `driver/SKILL.md` gains a short "Model-file introspection" section pointing agents at the stdlib inspector reader, plus a "Headless batch (not yet implemented)" stub.

Propagates the knowledge captured in [sim-proj#53](https://github.com/svd-ai-lab/sim-proj/pull/53) (which only updated `dev-docs/`) into the agent-facing skill.

## Test plan
- [x] Render `driver/base/reference/model_file_format.md` locally, verify links resolve.
- [x] Spot-check that the inspector import path matches what the driver actually exports.
- [x] Cross-link from `driver/SKILL.md` is visible at the top of the `base/` table.

Refs: sim-proj#51, sim-proj#53, sim-cli#47
