### PR TITLE
docs(driver): distill interface mapping into agent-facing skill

### DIFF
--- a/flotherm/SKILL.md
+++ b/flotherm/SKILL.md
@@ -92,8 +92,10 @@ via `GetDlgItem(1148)` + `SendMessage(WM_SETTEXT)` + `BM_CLICK`.
 
 | Path | What's there |
 |---|---|
-| `base/reference/floscript_modeling.md` | **FloSCRIPT model generation reference** — command vocabulary, patterns, step templates for building models from scratch via Claude. |
+| `base/reference/floscript_modeling.md` | **FloSCRIPT model generation reference** — command vocabulary, patterns, step templates for building models from scratch via Claude. Includes the `project_run_script` chaining pattern and a pointer to the full 620-command catalogue. |
 | `base/reference/postprocessing.md` | **Result extraction reference** — FloSCRIPT export commands (Path A), direct binary read of `msp_*/end/<Field>` files (Path B, format verified), GUI export (Path C), plus copy-paste verification probes. |
+| `base/reference/error_codes.md` | **Triage table** for `E/<NNNNN>` / `W/<NNNNN>` / `I/<NNNNN>` codes seen in `floerror.log` and `WinXP\bin\LogFiles\logFile*.xml`. Read this when an `ok=false` result needs a retry-vs-fatal decision. |
+| `base/reference/headless_bootstrap_investigation.md` | **What's ruled out, what's open** for headless project authoring (overlay approach is dead; GUI bootstrap is the next experiment) and `<load_from_library>` `E/15001` (9 syntactic forms ruled out; recording oracle deferred). |
 | `base/reference/` | FloSCRIPT XML patterns, GUI control sequences, Win32 message recipes. |
 | `base/workflows/` | End-to-end demo runs of typical Phase A `.pack` cases. |
 | `base/docs/` | Background on the GUI-automation approach and why headless batch is broken upstream. |

--- a/flotherm/base/reference/error_codes.md
+++ b/flotherm/base/reference/error_codes.md
@@ -1,0 +1,120 @@
+# Flotherm error code reference
+
+Triage table for FloSCRIPT / solver / translator codes encountered in `WinXP\bin\LogFiles\logFile*.xml` and `floerror.log`. Read this when an `ok=false` result lands and you need to decide whether to retry, change inputs, or surface fatally.
+
+> **Provenance.** Codes observed against Flotherm **2504**. The `E/` / `W/` / `I/` namespace is consistent across recent Simcenter Flotherm releases, but only 2504 was probed. If you're on `2406` / `2410` / `2412` / a later release and see a code not listed here, append it to this table — see "Refresh for another version" at the bottom.
+
+## Severity convention
+
+Flotherm prefixes diagnostic lines with `ERROR   E/<NNNNN>`, `WARN  W/<NNNNN>`, or `INFO    I/<NNNNN>` (note the variable whitespace — strip before regex matching). Codes are namespaced by the leading digits:
+
+| Range | Subsystem |
+|---|---|
+| `6xxx` | Tables / CSV export |
+| `9xxx` | Mesher / grid / domain |
+| `11xxx` | Project lifecycle (load / lock / file-type) |
+| `15xxx` | FloSCRIPT runtime (commands, properties, libraries, validation) |
+
+## Where codes show up
+
+1. **`<install>\WinXP\bin\LogFiles\logFile<timestamp>.xml`** — auto-recorded every GUI session, up to 5 retained. Each diagnostic appears as `<message text="ERROR …"/>`. Easiest channel for headless monitoring (file read; no UIA round-trip).
+2. **`%FLOUSERDIR%\<project>\floerror.log`** — persistent per-project log. Some 11xxx codes (notably `E/11029`) are written **only** here, not to stderr.
+
+The same code may appear in either or both channels. The driver's `lib/error_log.py` parses `floerror.log` today; a `tail_logfile_xml()` helper for the GUI log is on the roadmap (sim-cli; see comment at the bottom of this file).
+
+## Catalogue
+
+### `E/6xxx` — table / CSV export
+
+| Code | Severity | Observed message | Condition | Driver action |
+|---|---|---|---|---|
+| `E/6000` | error | `Failed to export Tables CSV file` | `export_table` / `csv_export_attribute` targeted a row/attribute that doesn't resolve, or the destination path is unwritable. | Surface to caller; do not retry without changing inputs. If it follows a failed `project_load`, recommend `disconnect` + `connect`. |
+
+### `E/9xxx` — mesher / grid
+
+| Code | Severity | Observed message | Condition | Driver action |
+|---|---|---|---|---|
+| `I/9033` | info | `Total number of Grid Cells are: <N>` | Pre-flight count. **A value of `1` is diagnostic of `E/9012`.** | Log only; surface as a metric in `query_status()`. |
+| `E/9012` | error | `Too few grid-cells to be solved NX = 1 and NY = 1` | Solver started against a project whose grid wasn't successfully built. Frequently downstream of `E/11029`. | Treat as fatal; correlate with the immediately preceding `E/11029`. Don't retry without a successful translator pass. |
+| `I/9001` | info | `Solver stopped: steady solution converged` | Successful solve marker. | Required positive signal for `query_status()` to flip `ok=true`. |
+
+### `E/11xxx` — project lifecycle
+
+| Code | Severity | Observed message | Condition | Driver action |
+|---|---|---|---|---|
+| `E/11008` | error | `Failed to import …` | `<project_import>` was called with an `import_type` that doesn't match the GUI menu text — e.g. `"pack"` instead of `"Pack File"`. | Validate `import_type` ∈ {`"Pack File"`, `"FloXML"`, `"PDML"`, …} before dispatch; recommend re-emit with the canonical value. |
+| `E/11013` | error | `Failed to get a lock: If project not already in use Select [Project/Load…/Unlock] to unlock` | A previous Flotherm session crashed leaving `group.lck` / `notes.lck`, or another process has the project open. | `<project_unlock project_name="…"/>` first, retry `<project_load>`. If repeated, fall back to `flounlock.exe -d <project>` from the shell. |
+| `E/11029` | error | `Failed unknown file type No reader for this file type — <project_dir>` | `floserv.exe` fell through to the translator code path with the project directory name treated as a filename. **The defining symptom of the broken `flotherm.bat -b` flag (ISSUE-001).** | Don't go through `flotherm.bat -b`; use direct `translator.exe -p <project>` + `solexe.exe -p <project>`. Treat as fatal. |
+| `E/15105` | error | `Failed to load project: <project_name>` | The project doesn't exist in `FLOUSERDIR`, or its `group.cat` / `PDProject` is corrupted. Often paired with `E/11013` when a stale lock blocks a re-load attempt. | If preceded by `E/11013`, retry after `<project_unlock>`. Otherwise treat as fatal; verify the project directory exists and contains `PDProject/group`. |
+
+### `E/15xxx` — FloSCRIPT runtime
+
+| Code | Severity | Observed message | Condition | Driver action |
+|---|---|---|---|---|
+| `E/15000` | error | `Command failed to find Attribute: <attribute>` | A command (`modify_attribute`, `csv_export_attribute`, …) referenced an attribute name that doesn't exist on the active project. | Surface; do not retry. Caller can verify with `<find>` + `<commonStringQueryConstraint>`. |
+| `E/15001` | error | `Command failed to find library node` | `<load_from_library>` was passed a `<library_name>` path that doesn't resolve. **Open question** — see ISSUE-006 in `known_issues.md`. | Surface; do not retry. Workaround: build attributes by hand with `<create_attribute>` + `<modify_attribute>`. |
+| `E/15002` | error | `Command failed to find property: <name>` | `modify_attribute` / `modify_geometry` / `modify_solver_control` was given a `property_name` the runtime doesn't recognise. The XSD declares `property_name` as `xs:string` so structural lint passes — only Flotherm catches it at runtime. **See ISSUE-005**. | Surface; do not retry. Always pair with the immediately following `W/15000` to confirm the script aborted. Suggest the recording-oracle workflow. |
+| `E/15013` | error | `FloSCRIPT validation error: <reason> On line <N>` | The submitted FloSCRIPT failed schema validation. Common causes: PCDATA in an empty element, unknown command name, missing required attribute. | The driver should validate locally (`lib/floscript.py:_validate_xsd()`) before dispatch — anything reaching this code is a driver bug or a hand-edited script. Surface with the line number. |
+| `W/15000` | warning | `Aborting XML due to previous error` | Companion warning that **always** follows a fatal `E/15xxx` to indicate the rest of the script was dropped. | Use as a positive signal that the script abort happened cleanly; absence after an `E/15xxx` is suspicious (Flotherm may still be running residual commands). |
+
+### Vendor-documented but not yet observed live
+
+These appear in the FloSCRIPT v11 tutorial / examples but haven't been observed in our 2504 sessions yet:
+
+- `E/15014` — FloSCRIPT validation error variants (different reason than `15013`).
+- `E/15100..15110` range — project lifecycle variants beyond `E/15105`.
+
+If you see one on the wire, append a row above with the exact message you observed.
+
+## Parsing recipe
+
+Both channels can be parsed with the same regex. For the GUI log XML:
+
+```python
+import re
+from xml.etree import ElementTree as ET
+
+CODE_RE = re.compile(r"\b([EWI])/(\d+)\s*-?\s*(.*)")
+SEVERITY = {"E": "error", "W": "warning", "I": "info"}
+
+def parse_logfile_xml(path):
+    """Yield (severity, code_int, code_full, message) for each <message text=…/>
+    in a Flotherm WinXP/bin/LogFiles/logFile*.xml file."""
+    tree = ET.parse(path)
+    for el in tree.getroot().iter("message"):
+        text = (el.get("text") or "").strip()
+        for token in text.split():
+            m = CODE_RE.match(token)
+            if m:
+                severity = SEVERITY[m.group(1)]
+                code_int = int(m.group(2))
+                rest = text.split(token, 1)[1].lstrip(" -")
+                yield severity, code_int, f"{m.group(1)}/{m.group(2)}", rest
+                break
+```
+
+For `floerror.log` the same regex works against each line (no XML envelope).
+
+The sim-cli driver's `lib/error_log.py` parses `floerror.log` today via string-match patterns. This catalogue is the prerequisite for an upcoming `tail_logfile_xml()` helper to bring the GUI log into the same pipeline.
+
+## Refresh for another version
+
+The error code namespace is stable across recent Flotherm releases per Siemens convention, but re-snapshot whenever you switch hosts:
+
+```powershell
+$ver = '<version>'
+$logs = "C:\Program Files\Siemens\SimcenterFlotherm\$ver\WinXP\bin\LogFiles"
+Get-ChildItem $logs -Filter '*.xml' |
+  ForEach-Object { Get-Content $_.FullName } |
+  Select-String -Pattern '[EWI]/\d+' |
+  ForEach-Object { ($_ -split '\s+' | Where-Object { $_ -match '^[EWI]/\d+' })[0] } |
+  Sort-Object -Unique
+```
+
+Compare the resulting set against the codes in this doc. Append rows for new ones. Don't speculate on the condition — only describe what you actually saw.
+
+## See also
+
+- Full FloSCRIPT command catalogue (620 commands, 6 schema roots): [`sim-proj/dev-docs/flotherm/floscript_catalog.md`](https://github.com/svd-ai-lab/sim-proj/blob/main/dev-docs/flotherm/floscript_catalog.md)
+- `known_issues.md` for the issue-tracker view (ISSUE-001 through ISSUE-006 cross-reference these codes)
+- `headless_bootstrap_investigation.md` for the open `E/15001` library-path question

--- a/flotherm/base/reference/floscript_modeling.md
+++ b/flotherm/base/reference/floscript_modeling.md
@@ -73,9 +73,9 @@ The patterns below cover the day-to-day modeling vocabulary. For the **complete*
 
 Use it when the patterns here don't have what you need (e.g. `csv_export_attribute`, `start_record_script`, `refresh_library`, `project_run_script`). Each entry lists the command name and its XSD complex-type so you can grep the schema for the attribute set.
 
-## Script chaining: `project_run_script` (unverified pointer)
+## Script chaining: `project_run_script` (verified on 2504)
 
-`<project_run_script file_name="…"/>` is documented in the schema as a way to run another FloSCRIPT from inside the running script context — in principle, this would collapse N `Macro → Play FloSCRIPT` clicks into one orchestrator script:
+`<project_run_script file_name="…"/>` runs another FloSCRIPT from inside the running script context. **Verified on Flotherm 2504 (2026-04-27)** — see "Verification" below for the probe artifacts. This collapses N `Macro → Play FloSCRIPT` clicks into one orchestrator script:
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
@@ -88,9 +88,24 @@ Use it when the patterns here don't have what you need (e.g. `csv_export_attribu
 </xml_log_file>
 ```
 
-> ⚠ **Not verified on Flotherm 2504 yet.** Surfaced via [lixiekun/flotherm-automation#1](https://github.com/lixiekun/flotherm-automation/issues/1#issuecomment-4324008578) (2026-04-27) by a third party. The command appears in all 7 schema roots, but schema presence ≠ playback support — `<load_from_library>` (ISSUE-006) and `flotherm.bat -f` (ISSUE-003) are both schema-valid but runtime no-ops. Until someone records a 2-line probe (`<project_load>` + `<quit>`) and confirms it actually quits Flotherm, treat this as a *pointer to investigate*, not an established pattern.
+The outer orchestrator still needs **one** GUI invocation (Macro → Play FloSCRIPT, automated by sim-cli's UIA driver). After that, every `<project_run_script>` runs in-process; no further UI clicks required. `<quit/>` is the FloSCRIPT primitive to close Flotherm cleanly at the end — also verified to work in playback.
 
-A cheap verification probe: write a 2-line orchestrator that just loads a project and quits. Play it via `Macro → Play FloSCRIPT`. If Flotherm closes, chaining works in principle and you can extend with `<project_run_script>` calls. If Flotherm stays open, the directive is record-only and this whole pattern is dead.
+`project_run_script` is available in all 7 schema roots — surfaced via [lixiekun/flotherm-automation#1](https://github.com/lixiekun/flotherm-automation/issues/1#issuecomment-4324008578) (2026-04-27).
+
+### Verification (Flotherm 2504, 2026-04-27)
+
+Three independent probes settled the question:
+
+1. **`<quit/>`-only probe.** A 1-command orchestrator with just `<quit/>`. Flotherm GUI closes after play. Confirms `<quit>` works in playback.
+2. **Typo probe.** Outer calls inner via `<project_run_script>`; inner has a deliberate XSD-invalid `<start_record_script filename="…"/>` (wrong attribute name — should be `file_name`). The GUI session log captured `E/15013 - FloSCRIPT validation error: attribute 'filename' is not declared … On line 3` — and **line 3 is in the inner script**. Flotherm parsed and validated the inner, which would not happen if `<project_run_script>` were record-only.
+3. **Inner-quit probe.** Outer calls inner via `<project_run_script>`; inner contains only `<quit/>`. After play, the `flomain` GUI process is gone (only `floserv`/`floview` remain). Since the outer has no `<quit/>`, the close came from the inner — final confirmation that the chain runs in-process.
+
+The "schema-valid but runtime-no-op" risk that sank `<load_from_library>` (ISSUE-006) and `flotherm.bat -f` (ISSUE-003) doesn't apply here.
+
+### Caveats from verification
+
+- **`<project_load project_name="…"/>` requires the project to already be registered in `group.cat`** (per the canonical `base/workflows/solve_mobile_demo.xml` note). Loading a brand-new project from a fresh `sim connect` session produces `E/15105 - Failed to load project`. If you want the orchestrator to load a project, use `<project_import>` first or pre-register via the GUI.
+- **The driver's `ok` flag flips false on `<quit/>`-bearing scripts** because Flotherm closes underneath the session. Expected — re-`connect` for follow-up commands.
 
 ## Error triage
 

--- a/flotherm/base/reference/floscript_modeling.md
+++ b/flotherm/base/reference/floscript_modeling.md
@@ -65,6 +65,37 @@ If the session dies mid-build, reload from the last checkpoint:
 
 ---
 
+## Full command catalogue
+
+The patterns below cover the day-to-day modeling vocabulary. For the **complete** list of FloSCRIPT commands — 620 direct commands across 6 schema roots (`xml_log_file`, `cc_xml_log_file`, `eda_xml_log_file`, `floviz_xml_log_file`, `flopack_xml_log_file`, `mcad_xml_log_file`) plus 237 complex types — see the catalogue in sim-proj:
+
+[`sim-proj/dev-docs/flotherm/floscript_catalog.md`](https://github.com/svd-ai-lab/sim-proj/blob/main/dev-docs/flotherm/floscript_catalog.md)
+
+Use it when the patterns here don't have what you need (e.g. `csv_export_attribute`, `start_record_script`, `refresh_library`, `project_run_script`). Each entry lists the command name and its XSD complex-type so you can grep the schema for the attribute set.
+
+## Script chaining: `project_run_script` (unverified pointer)
+
+`<project_run_script file_name="…"/>` is documented in the schema as a way to run another FloSCRIPT from inside the running script context — in principle, this would collapse N `Macro → Play FloSCRIPT` clicks into one orchestrator script:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<xml_log_file version="1.0">
+  <project_load project_name="my_project"/>
+  <project_run_script file_name="step_01_geometry.xml"/>
+  <project_run_script file_name="step_02_solve.xml"/>
+  <project_run_script file_name="step_03_export.xml"/>
+  <quit/>
+</xml_log_file>
+```
+
+> ⚠ **Not verified on Flotherm 2504 yet.** Surfaced via [lixiekun/flotherm-automation#1](https://github.com/lixiekun/flotherm-automation/issues/1#issuecomment-4324008578) (2026-04-27) by a third party. The command appears in all 7 schema roots, but schema presence ≠ playback support — `<load_from_library>` (ISSUE-006) and `flotherm.bat -f` (ISSUE-003) are both schema-valid but runtime no-ops. Until someone records a 2-line probe (`<project_load>` + `<quit>`) and confirms it actually quits Flotherm, treat this as a *pointer to investigate*, not an established pattern.
+
+A cheap verification probe: write a 2-line orchestrator that just loads a project and quits. Play it via `Macro → Play FloSCRIPT`. If Flotherm closes, chaining works in principle and you can extend with `<project_run_script>` calls. If Flotherm stays open, the directive is record-only and this whole pattern is dead.
+
+## Error triage
+
+When playback fails, runtime errors land in the Message Window dock and `floerror.log`. The catalogue of every `E/<NNNNN>` / `W/<NNNNN>` / `I/<NNNNN>` code observed on 2504, with severity, message template, condition, and suggested driver action, is in [`error_codes.md`](error_codes.md). Read it before retrying a failed `sim exec`.
+
 ## Command Reference
 
 ### Create geometry

--- a/flotherm/base/reference/headless_bootstrap_investigation.md
+++ b/flotherm/base/reference/headless_bootstrap_investigation.md
@@ -1,0 +1,102 @@
+# Headless authoring + library lookup — what we ruled out, what's still open
+
+This page records the closed and open questions from the 2026-04-27 reverse-engineering experiments. It's not a how-to — it's a "don't repeat these probes" map for future agents.
+
+## Background
+
+Two long-standing pain points blocked fully-headless Flotherm authoring on 2504:
+
+1. **Headless project authoring** — `flotherm.bat -b` is broken (ISSUE-001). Direct `translator.exe` + `solexe.exe` re-solves an existing project but can't *create* one. The intermediate `flogate_cl` chain (`FloXML → PDML → floimport`) produces a project shell that translator silently no-ops on.
+2. **`<load_from_library>` returns `E/15001`** regardless of the `<library_name>` form tried (ISSUE-006). The path was an "open question" in `playbook.md` for weeks.
+
+Both were probed in the 2026-04-27 batch.
+
+---
+
+## Closed: overlay onto a working scaffold is *not* viable
+
+**Hypothesis.** Take a solved donor project (Mobile_Demo). Overwrite only `PDProject/group` with a new model's PDML (built via `flogate_cl -iFloXML -oPDML`). Keep the donor's `DataSets/BaseSolution/` directories and let translator re-translate against the new model, reusing the existing scaffolding.
+
+**Result.** Translator crashes with **`STATUS_STACK_BUFFER_OVERRUN`** (`0xC0000409`) at offset `0x1cba8` in `ucrtbase.dll`. The Windows Application Event Log captures it as a faulting application crash; nothing reaches `floerror.log`.
+
+**What this proves:**
+
+- ✅ **`PDProject/group` *is* read by translator.** That was an open question — the crash empirically settles it. Translator is not blind to the file.
+- ❌ **You cannot reuse a solved project's `DataSets/BaseSolution/` with a different model's `PDProject/group`.** The mesh-geometry mismatch tickles a runtime stack-buffer guard. It's the first time we've ever seen translator produce a *loud* error on a FloXML-authored project — previously it just silently no-op'd.
+- ⚠️ **The `flopdupdate` / `floupdateall` / `flocatalogue` chain has undocumented arg requirements.** The piecemeal invocations I tried are wrong — the canonical example is the `flounpackproject.bat` wrapper, which builds a tempfile listing the project's component files and feeds that to `-F`. Don't call these CLIs without copying the wrapper's full incantation.
+
+**Reproduction.** See [`sim-proj/dev-docs/flotherm/experiments/2026-04-27-overlay/`](https://github.com/svd-ai-lab/sim-proj/tree/main/dev-docs/flotherm/experiments/2026-04-27-overlay) — `RESULT.md` plus the captured `step3.log` and tree diffs.
+
+### Next experiments (in order of cheapness)
+
+1. **GUI headless bootstrap.** Launch Flotherm with the imported (FloXML-derived) project briefly, let the GUI create a fresh `BaseSolution/` matching the new geometry, then kill the GUI and call translator. The scaffolding now matches — translator should translate without crash. Requires UIA, but we have that wired already.
+2. **Round-trip via Flotherm's own FloXML export** (if such a command exists). Schemas grep already shows `export_compact_model_floxml` but no project-level `export_floxml`. Confirming whether a menu action exists is a recording-oracle task — deferred until a human is available.
+
+---
+
+## Narrowed but still open: `<load_from_library>` returns `E/15001`
+
+**Hypothesis under test.** The XSD declares `<library_name>` as a recursive `<library>` chain (`libraryIDNode`):
+
+```xml
+<xs:complexType name="libraryIDNode">
+  <xs:choice minOccurs="0" maxOccurs="1">
+    <xs:element name="library" type="libraryIDNode" />
+  </xs:choice>
+  <xs:attribute name="name" use="required"/>
+  <xs:attribute name="count" type="xs:int"/>
+</xs:complexType>
+```
+
+Maybe the failures come from one of the **9 syntactic axes**:
+
+1. filesystem names throughout (`FloTHERM_Libraries → … → Aluminum__Pure_`)
+2. filesystem ancestors, **display** name leaf (`… → Aluminum (Pure)`)
+3. display names throughout (`FloTHERM Libraries → … → Aluminum (Pure)`)
+4. leaf-only, filesystem name (`<library name="Aluminum__Pure_"/>`)
+5. leaf-only, display name (`<library name="Aluminum (Pure)"/>`)
+6. prepend `Libraries/` top
+7. add `count="1"` at every level
+8. skip the `FloTHERM_Libraries` root
+9. display leaf, filesystem ancestors
+
+**Result.** All 9 fail identically:
+
+```
+ERROR   E/15001 - Command failed to find library node
+WARN    W/15000 - Aborting XML due to previous error
+```
+
+**What this proves.** None of the syntactic axes we vary make any difference. The failure cause is **environmental, not syntactic**.
+
+### Three remaining hypotheses (descending likelihood)
+
+1. **Missing precondition.** The library system might be loaded **lazily** by the GUI on first browse; without a prior `<refresh_library>` or `<import_library>`, the runtime has no library tree to look up against. Or a geometry must be **selected** (`<select_geometry>`), not just **named**, before resolution. Or some implicit GUI state (Materials tab open, library browser visible).
+2. **Record-only command.** Like the broken `flotherm.bat -f` (ISSUE-003), the schema accepts it but the playback path doesn't actually wire it up. Several record-only commands sit in the catalogue (`pause_record_script`, `resume_record_script`, `solve_idle_event`).
+3. **UUID addressing.** Some `library.catalog` entries use a 6-tuple integer suffix (`0,2,0,0,0,0`); that may be the canonical node ID, with `name` being a display label that the playback path doesn't translate back.
+
+### How to discriminate (deferred — needs a human at the GUI)
+
+```
+1. Flotherm GUI:  Macro → Record FloSCRIPT → choose a fresh script name
+2. Drag-drop Aluminum (Pure) from Library browser onto a cuboid
+3. Macro → Stop FloSCRIPT
+4. Open the recorded .xml — that is the canonical <load_from_library> form
+```
+
+The recording oracle settles it in one shot. Until then, **build attribute-by-hand** with `<create_attribute>` + `<modify_attribute>` for materials and sources. Don't suggest any of forms 1-9 in your FloSCRIPT — they're all wrong.
+
+A cheaper autonomous probe to try first: prepend `<refresh_library/>` (or `<import_library>` — schema lookup needed) to one of the failing scripts. If it passes, hypothesis #1 is the answer.
+
+**Reproduction.** See [`sim-proj/dev-docs/flotherm/experiments/2026-04-27-library-paths/`](https://github.com/svd-ai-lab/sim-proj/tree/main/dev-docs/flotherm/experiments/2026-04-27-library-paths) — `RESULT.md` plus the 7 standalone probe scripts.
+
+---
+
+## Quick-reference: what to do *today*
+
+| Task | Path |
+|---|---|
+| Re-solve an existing project headlessly | Direct `translator.exe -p <ws> -n1` + `solexe.exe -p <ws>`, after `flotherm.bat -env`. **Works.** See `SKILL.md` "Direct batch" section. |
+| Create a new project from scratch | GUI automation (Macro → Play FloSCRIPT). Headless-bootstrap is still blocked; the next experiment is GUI bootstrap + headless re-translate. |
+| Author materials / sources | `<create_attribute>` + `<modify_attribute>`. Don't try `<load_from_library>` — see ISSUE-006. |
+| Chain N FloSCRIPTs after one GUI click | `<project_run_script file_name="…"/>` is in the schema and may work — see the unverified pointer in `floscript_modeling.md` "Script chaining" section. Verify with a 2-line probe before relying on it. |

--- a/flotherm/base/reference/headless_bootstrap_investigation.md
+++ b/flotherm/base/reference/headless_bootstrap_investigation.md
@@ -99,4 +99,4 @@ A cheaper autonomous probe to try first: prepend `<refresh_library/>` (or `<impo
 | Re-solve an existing project headlessly | Direct `translator.exe -p <ws> -n1` + `solexe.exe -p <ws>`, after `flotherm.bat -env`. **Works.** See `SKILL.md` "Direct batch" section. |
 | Create a new project from scratch | GUI automation (Macro → Play FloSCRIPT). Headless-bootstrap is still blocked; the next experiment is GUI bootstrap + headless re-translate. |
 | Author materials / sources | `<create_attribute>` + `<modify_attribute>`. Don't try `<load_from_library>` — see ISSUE-006. |
-| Chain N FloSCRIPTs after one GUI click | `<project_run_script file_name="…"/>` is in the schema and may work — see the unverified pointer in `floscript_modeling.md` "Script chaining" section. Verify with a 2-line probe before relying on it. |
+| Chain N FloSCRIPTs after one GUI click | `<project_run_script file_name="…"/>` — **verified on 2504** (2026-04-27). See `floscript_modeling.md` "Script chaining" for the orchestrator pattern and the three-probe verification. |

--- a/flotherm/known_issues.md
+++ b/flotherm/known_issues.md
@@ -332,3 +332,52 @@ the file. The recording contains the exact syntax Flotherm uses internally.
 See the "Ground-truth oracle" section in
 [reference/floscript_modeling.md](base/reference/floscript_modeling.md).
 
+## ISSUE-006: `<load_from_library>` returns `E/15001` regardless of `<library_name>` form
+
+**Date discovered**: 2026-04-27
+**Severity**: Medium — blocks one path for material assignment; workaround exists
+**Status**: Narrowed but open. 9 syntactic forms ruled out; recording-oracle probe required to settle.
+
+### Symptom
+
+`<load_from_library>` always returns:
+
+```
+ERROR   E/15001 - Command failed to find library node
+WARN    W/15000 - Aborting XML due to previous error
+```
+
+The XSD declares `<library_name>` as a recursive `<library>` chain (`libraryIDNode`), so we tested 9 syntactic variations:
+
+1. filesystem names throughout
+2. filesystem ancestors, display name leaf
+3. display names throughout
+4. leaf-only, filesystem name
+5. leaf-only, display name
+6. prepend `Libraries/` top
+7. with `count` attribute at every level
+8. skip the `FloTHERM_Libraries` root
+9. display leaf, filesystem ancestors
+
+All 9 fail identically. The failure cause is **environmental, not syntactic** — none of the schema-driven axes we vary make a difference.
+
+### Three remaining hypotheses
+
+1. **Missing precondition** — library tree may be lazy-loaded; needs `<refresh_library/>` or `<import_library>` first, or a geometry `<select_geometry>` selection, or other implicit GUI state.
+2. **Record-only command** — the playback path may not actually wire it up (similar to ISSUE-003's `flotherm.bat -f`).
+3. **UUID addressing** — `library.catalog` entries carry a 6-tuple integer suffix that may be the canonical node ID.
+
+### Workaround
+
+Build attribute-by-hand with `<create_attribute>` + `<modify_attribute>`. Don't try `<load_from_library>` until the recording oracle settles which precondition is missing.
+
+### Resolution path
+
+```
+Macro → Record FloSCRIPT → drag-drop a material from the GUI library onto a geometry → Stop → read recording
+```
+
+The recorded XML is the canonical form. Until then, see `base/reference/headless_bootstrap_investigation.md` for the closed-vs-open question map.
+
+Reproduction artifacts: [`sim-proj/dev-docs/flotherm/experiments/2026-04-27-library-paths/`](https://github.com/svd-ai-lab/sim-proj/tree/main/dev-docs/flotherm/experiments/2026-04-27-library-paths).
+

--- a/ltspice/SKILL.md
+++ b/ltspice/SKILL.md
@@ -35,7 +35,7 @@ Python. The file format understanding and platform quirks are the same.
 |---|---|---|
 | `.net` / `.cir` / `.sp` netlist | ✅ today | SPICE3 syntax; first line is title (ignored by solver); must contain at least one analysis directive |
 | `.asc` schematic (flat, library-local) | 🟡 sim-ltspice v0.1+ — on macOS goes through our native asc2net; on Windows/wine goes through LTspice's own `-netlist` | Schematic opens in LTspice GUI for human review |
-| `.asc` schematic (hierarchical or custom lib) | 🟡 Windows / wine only | Requires LTspice's own `-netlist` pass; on macOS raises `MacOSCannotFlatten` with guidance to run `sim --host <win1>` |
+| `.asc` schematic (hierarchical or custom lib) | 🟡 Windows / wine only | Routed through `sim_ltspice.schematic_to_netlist` (the in-process Python flattener, since LTspice 26.0.1's `-netlist` flag is broken). On macOS raises `MacOSCannotFlatten` with guidance to route via a Windows host. |
 | `.raw` / `.log` inputs | ❌ outputs only | Do not pass these to `sim run` |
 
 When you produce a netlist for an agent workflow, **always use `.net`**.
@@ -44,19 +44,31 @@ driver has the fewest edge cases for it.
 
 ## Platform capabilities
 
-| Capability | macOS 17.x native | Windows 26.x | Linux + wine |
-|---|---|---|---|
-| `-b <netlist>` batch run | ✅ | ✅ | ✅ |
-| `-Run -b` | ❌ (ignored) | ✅ | ✅ |
-| `-ascii` raw output | ❌ | ✅ | ✅ |
-| `-netlist <asc>` schematic→netlist | ❌ | ✅ | ✅ |
-| `.asc` direct input to sim run | native asc2net only (flat + library-local) | full | full |
-| `.log` encoding | UTF-16 LE (no BOM) | UTF-8 | UTF-16 LE |
-| `.raw` header encoding | UTF-16 LE | UTF-16 LE | UTF-16 LE |
+| Capability | macOS 17.x native | macOS 26.x native | Windows 26.x | Linux + wine |
+|---|---|---|---|---|
+| `-b <netlist>` batch run | ✅ | ✅ | ✅ | ✅ |
+| `-Run -b` | ❌ (ignored) | ✅ | ✅ | ✅ |
+| `-ascii` raw output | ❌ | ✅ | ✅ | ✅ |
+| `-netlist <asc>` schematic→netlist | ❌ | ✅ † | ⚠️ broken on 26.0.1 | ✅ |
+| `-ini <path>` reproducible-state run | ✅ | ✅ | ✅ | ✅ |
+| `-I<path>` symbol path injection | ✅ | ✅ | ✅ | ✅ |
+| `-FastAccess` `.raw` reformat | ❌ | ✅ | ✅ | ✅ |
+| `-sync` re-extract bundled libs | ❌ | ✅ | ✅ | ✅ |
+| `-version` print version (stderr) | ✅ | ✅ | ✅ | ✅ |
+| `.asc` direct input to sim run | native asc2net only (flat + library-local) | native asc2net | full | full |
+| `.log` encoding | UTF-16 LE (no BOM) | UTF-8 | UTF-8 | UTF-16 LE |
+| `.raw` header encoding | UTF-16 LE | UTF-16 LE | UTF-16 LE | UTF-16 LE |
 
-If you need a feature Windows has and macOS lacks, route through
-`sim --host <win1>`. See `../sim-cli/SKILL.md` for the HTTP dispatch
-model.
+† On macOS 26 the `-netlist` flag works but `sim-ltspice`'s preferred
+path is the in-process `schematic_to_netlist` flattener — no LTspice
+binary touched. Use `-netlist` only when the flattener can't handle a
+hierarchy or custom-symbol case.
+
+If you need a feature macOS lacks (or to dodge the 26.0.1 `-netlist`
+regression), route through `sim --host <windows-host>`. See
+`../sim-cli/SKILL.md` for the HTTP dispatch model. The full
+flag-by-flag table lives in
+[`base/reference/command_line_switches.md`](base/reference/command_line_switches.md).
 
 ## Hard constraints (LTspice-specific)
 
@@ -106,7 +118,11 @@ Always read `base/reference/`, then the relevant snippets + workflows.
 | `base/reference/spice_directives.md` | Cheat sheet: `.tran`, `.ac`, `.dc`, `.op`, `.noise`, `.meas`, `.step`, `.param`, `.ic`, `.nodeset`, `.save` |
 | `base/reference/element_syntax.md` | R / C / L / V / I / D / Q / M / X instance syntax + common model options |
 | `base/reference/result_extraction.md` | Three layers (`.meas` → `RawRead` cursors → arrays) + `eval` / `to_csv` / `to_dataframe`. Read before reaching for `.raw` |
-| `base/reference/platform_dispatch.md` | When to use `--host <win1>`; macOS flat-asc-only constraint |
+| `base/reference/platform_dispatch.md` | When to route to a Windows host; macOS flat-asc-only constraint |
+| `base/reference/command_line_switches.md` | Complete LTspice CLI flag table (16 flags + 2 env vars) — verbatim from the shipped help bundle. Read before constructing any non-default `LTspice.exe` invocation |
+| `base/reference/search_path_resolution.md` | `-I<path>` → ini → schematic dir → `lib/sym/` → `lib/sub/`. The order LTspice walks when resolving symbols and `.lib` includes |
+| `base/reference/log_channel_limits.md` | What `<deck>.log` does and doesn't capture. No GUI session journal — agents must triage hangs vs. solver errors differently |
+| `base/reference/component_models.md` | The 8 generic-model files (`lib/cmp/standard.{bjt,mos,dio,jft,cap,ind,res,bead}`). UTF-16 closed enum used by `Value <model>` references on primitives |
 | `base/snippets/rc_lowpass.net` | Minimal RC transient with one `.meas` |
 | `base/snippets/rlc_ac.net` | Series-RLC band-pass AC sweep — complex `.raw` traces, resonance `.meas` |
 | `base/snippets/inverting_amp.net` | Inverting op-amp with `.include LTC.lib` and gain `.meas` |
@@ -120,14 +136,18 @@ Always read `base/reference/`, then the relevant snippets + workflows.
 ### Documentation lookup
 
 LTspice ships an extensive offline help set on Windows at
-`%LOCALAPPDATA%\Programs\ADI\LTspice\LTspiceHelp\` (~145 HTML files,
-comprehensive SPICE + analysis reference). macOS ships no HTML help
-(the native app has an in-GUI help only).
+`%LOCALAPPDATA%\Programs\ADI\LTspice\LTspiceHelp\` (~738 HTML files
+in 26.x — comprehensive SPICE + analysis reference). macOS 17 ships
+no HTML help (in-GUI help only); macOS 26 has parity with Windows.
 
-For authoritative syntax questions when on Windows:
+The community mirror at [ltwiki.org](https://ltwiki.org/) indexes the
+same content and is searchable from any platform without LTspice
+installed locally.
+
+For authoritative syntax questions on a Windows host:
 
 ```bash
-sim --host 100.90.110.79 exec 'cat "%LOCALAPPDATA%\Programs\ADI\LTspice\LTspiceHelp\<topic>.html"'
+sim --host <windows-host> exec 'cat "%LOCALAPPDATA%\Programs\ADI\LTspice\LTspiceHelp\<topic>.htm"'
 ```
 
 For anyone else, consult the LTspice Users' Guide PDF (search
@@ -164,4 +184,26 @@ convention.
 5. **macOS `.asc` refusal.** If `sim run my.asc --solver ltspice`
    errors with `MacOSCannotFlatten`, either (a) ensure the schematic
    uses only shipped-library symbols and no hierarchy, or (b) route
-   via `sim --host <win1>`.
+   via `sim --host <windows-host>`.
+
+6. **`-netlist` is broken on LTspice 26.0.1 (Windows).** The flag
+   silently hangs — no `.net` written, no exit code, no signal.
+   Don't shell out to `LTspice.exe -netlist`; use
+   `sim_ltspice.schematic_to_netlist` instead. See
+   [`base/reference/command_line_switches.md`](base/reference/command_line_switches.md)
+   for the full regression note.
+
+7. **No GUI session log.** Unlike Flotherm, LTspice writes nothing
+   for GUI events (popups, schematic-load failures, updater
+   dialogs). The only file channel is the per-deck `<deck>.log`,
+   which only covers solver-time errors. For hangs and GUI-only
+   failures, the `sim_ltspice.runner` 300 s timeout is the
+   triage primitive — see
+   [`base/reference/log_channel_limits.md`](base/reference/log_channel_limits.md).
+
+8. **Generic-model lookup is closed.** `Q1 c b e 2N9999` will fail
+   at solve time unless `2N9999` is in `lib/cmp/standard.bjt` or
+   pulled in via `.lib`/`.include`. The 8 `lib/cmp/standard.*`
+   files are the closed enum — see
+   [`base/reference/component_models.md`](base/reference/component_models.md)
+   for offline lint via `ComponentModelCatalog`.

--- a/ltspice/base/reference/command_line_switches.md
+++ b/ltspice/base/reference/command_line_switches.md
@@ -1,0 +1,128 @@
+# LTspice command-line switches
+
+Reproduced verbatim from the help bundle shipped with LTspice 26
+(`LTspiceHelp/commandlineswitches.htm`). This is the **complete**
+documented surface — anything not listed below is not a real flag.
+
+| Flag | Description |
+|---|---|
+| `-alt` | Set solver to **Alternate**. Overridable by the netlist. |
+| `-ascii` | Use ASCII `.raw` files. *"Seriously degrades program performance."* (vendor warning verbatim) |
+| `-b` | Run in **batch mode**. `LTspice.exe -b deck.cir` leaves the data in `deck.raw`. |
+| `-big` / `-max` | Start as a maximized window. (GUI mode.) |
+| `-encrypt` | Encrypt a model library (for 3rd-party model vendors). |
+| `-FastAccess` | Convert a binary `.raw` to **Fast Access** format. |
+| `-FixUpSchematicFonts` / `-FixUpSymbolFonts` | Migrate very-old user files to modern font defaults. |
+| `-ini <path>` | Override the default settings file (`%APPDATA%\LTspice.ini` on Windows, `~/Library/Preferences/LTspice.ini` on macOS). |
+| `-I<path>` | Insert `<path>` into the symbol + file search paths. **Must be the last argument; no space between `-I` and `<path>`.** |
+| `-netlist` | Batch-convert a `.asc` schematic to a `.net` netlist. |
+| `-norm` | Set solver to **Normal**. Overridable by the netlist. |
+| `-PCBnetlist` | Batch-convert `.asc` to PCB-format netlist. |
+| `-Run` | Open the schematic on the cmdline and immediately simulate (no need to press Run). |
+| `-sync` | Update component libraries (re-extracts the bundled `lib.zip` / `examples.zip` to the user-data dir). |
+| `-version` | Print the LTspice version. |
+
+Two environment variables are also documented:
+
+- `PASTE_OMEGA` — when set, paste the UNICODE Ω symbol on the
+  clipboard instead of `"Ohm"`.
+- `CAPITAL_KILO` — when set, use upper-case `K` for *all* metric
+  multipliers, not just those ≥ 1000.
+
+## Three modes the sim-ltspice driver actually uses
+
+```bash
+# Batch-solve a netlist  →  emits sibling .log + .raw
+LTspice.exe -b deck.net                    # Windows / wine
+/Applications/LTspice.app/Contents/MacOS/LTspice -b deck.net  # macOS
+
+# Schematic → netlist (one-shot conversion)
+LTspice.exe -netlist deck.asc              # Windows
+# ⚠️ BROKEN on LTspice 26.0.1 — see "Known regressions" below.
+
+# Reproducible CI run with a fresh ini (no user state leakage)
+LTspice.exe -ini fixtures/clean.ini -b deck.net
+```
+
+## Known regressions and gotchas
+
+### `-netlist` is broken on LTspice 26.0.1 (Windows)
+
+`LTspice.exe -netlist <file.asc>` spawns a windowless process that
+sits at ~0% CPU indefinitely and never writes a `.net`. Reproduced
+against LTspice's own shipped `examples/Educational/MonteCarlo.asc`.
+Workarounds:
+
+1. **Preferred:** use `sim_ltspice.schematic_to_netlist` (the
+   in-process Python flattener). No LTspice binary involved.
+2. Fall back to LTspice XVII (17.2.4) for `.asc` → `.net` if you have
+   it side-by-side.
+
+### `-Run -b` from SSH session 0 hangs indefinitely
+
+LTspice GUI cannot render under `WinSta0\Service`, the session SSH
+processes land in. A `-b` invocation from SSH on Windows hangs (no
+output, never terminates). Workarounds: run `sim serve` from an
+interactive desktop (RDP) session, or invoke from inside an RDP
+shell. The `sim-ltspice` runner has a 300 s default timeout that
+makes this fail-fast rather than hang forever.
+
+### `-Run` is a no-op for `-b`
+
+`-b` already starts simulating immediately. `-Run -b` is the form
+sim-ltspice emits on Windows because some older docs paired them; it
+behaves identically to `-b` alone.
+
+### `-I<path>` ordering trap
+
+`-I` *must be the last argument*, and there is *no space* between
+`-I` and the path. `-I C:\my\syms` is wrong. `-IC:\my\syms` is right.
+Quoting rules apply for paths with spaces: `"-IC:\Program Files\my syms"`.
+
+### `-ini <path>` tradeoff
+
+The `.ini` is INI-with-binary-tail (4 KB-ish). The header is plain
+text (`[Options]`, `UUID=…`, `CaptureAnalytics=…`); the rest is a
+binary blob holding window positions, recent-files, plot defaults,
+search paths. For CI, an empty file works — LTspice repopulates
+defaults on first write.
+
+## Recipes
+
+### Reproducible CI run
+
+```bash
+mkdir -p tests/fixtures/ltspice
+echo "[Options]" > tests/fixtures/ltspice/clean.ini
+echo "CaptureAnalytics=false" >> tests/fixtures/ltspice/clean.ini
+
+LTspice.exe -ini "$(pwd)/tests/fixtures/ltspice/clean.ini" -b deck.net
+```
+
+### Inject a custom symbol path at run time
+
+```bash
+# Last-arg discipline; no space after -I
+LTspice.exe -b deck.net -I"$(pwd)/vendor-symbols"
+```
+
+### Reformat a `.raw` to ASCII (post-hoc)
+
+```bash
+LTspice.exe -b -ascii deck.net   # at simulate time
+# or, if you already have a binary .raw, reformat with -FastAccess (different format)
+```
+
+## What's *not* a flag
+
+Common myths and look-alikes that are not actually CLI flags:
+
+- `-o <path>` / `--output` — does not exist; output filenames derive from the input.
+- `-q` / `-quiet` — does not exist; redirect stdout/stderr to suppress.
+- `-h` / `-help` / `-?` — does not exist (GUI-only app, no stdout help).
+- `-batch` — does not exist; the flag is just `-b`.
+- `--version` (double dash) — does not exist; LTspice's flag is `-version`.
+
+Source of truth lives in the shipped help bundle:
+`%LOCALAPPDATA%\Programs\ADI\LTspice\LTspiceHelp\commandlineswitches.htm`
+on Windows, or its [community mirror at ltwiki.org](https://ltwiki.org/LTspiceHelp/LTspiceHelp/Command_Line_Switches.htm).

--- a/ltspice/base/reference/component_models.md
+++ b/ltspice/base/reference/component_models.md
@@ -1,0 +1,80 @@
+# Generic component model catalogue (`lib/cmp/standard.*`)
+
+LTspice ships **eight** files under `<user-data>/lib/cmp/` —
+one per primitive device kind. Together they define the closed enum
+of generic-model names you can reference via `Value <model-name>` on
+the corresponding primitive symbol (`Q1`, `M1`, `D1`, …). Anything
+not in these files must come from a `.subckt` (in `lib/sub/` or a
+custom `.lib`/`.include`).
+
+## The eight files
+
+| File | Element kind | Models defined | Sample names |
+|---|---|---|---|
+| `standard.bjt` | BJT (`Q…`) | NPN/PNP transistors | `2N2222`, `2N3904`, `2N3906`, `BC547`, `BC557` |
+| `standard.mos` | MOSFET (`M…`) | N/P-channel FETs | `IRF540`, `IRF9540`, `Si4410DY`, `2N7000` |
+| `standard.dio` | Diode (`D…`) | Rectifier / Schottky / Zener | `1N4148`, `1N4007`, `1N5817`, `1N4734` |
+| `standard.jft` | JFET (`J…`) | N/P-channel JFETs | `2N3819`, `2N5460` |
+| `standard.cap` | Capacitor (`C…`) | Non-ideal models with ESR/ESL | E.g. specific caps modelled with parasitics |
+| `standard.ind` | Inductor (`L…`) | Non-ideal models | E.g. core-loss + saturation models |
+| `standard.res` | Resistor (`R…`) | Non-ideal models | E.g. wirewound parasitic Ls |
+| `standard.bead` | Ferrite bead | EMI-suppression beads | Vendor-specific bead models |
+
+## Encoding gotcha — UTF-16 LE
+
+These files are **UTF-16 little-endian** (no BOM in some, BOM in
+others depending on history). Read with `encoding='utf-16'` in
+Python; reading as UTF-8 yields space-padded ASCII gibberish:
+
+```text
+*   C o p y r i g h t   ?   2 0 0 0   ...
+. m o d e l   2 N 2 2 2 2   N P N ( I S = 1 E - 1 4   V A F = 1 0 0
+```
+
+This is a recurring LTspice theme (the macOS `.log` is also UTF-16 LE
+no-BOM). Always sniff before reading.
+
+## Why agents should care
+
+These are the **only** generic-model names LTspice resolves without
+needing a `.subckt` import. If you write:
+
+```spice
+Q1 c b e 2N2222
+```
+
+…and `2N2222` is in `standard.bjt`, the netlist works. If you write
+`Q1 c b e 2N9999` and `2N9999` is not there, LTspice errors at
+solve time with `unknown subckt or model: 2N9999`.
+
+## Offline lint
+
+`sim_ltspice.cmp.ComponentModelCatalog` (forthcoming, see
+[sim-ltspice#TBD](https://github.com/svd-ai-lab/sim-ltspice)) will
+parse all eight files at install-discovery time and expose:
+
+```python
+from sim_ltspice import ComponentModelCatalog
+
+cat = ComponentModelCatalog()
+cat.find("2N2222")           # → ModelDef(name="2N2222", kind="bjt", ...)
+cat.find("2N9999")           # → None
+cat.models("bjt")            # → list of all bjt model names
+cat.kinds()                  # → ("bjt", "mos", "dio", "jft", "cap", "ind", "res", "bead")
+```
+
+The point is to flag bad model references **before** running LTspice
+— catching typos in CI / `sim lint` rather than mid-simulation.
+
+## How it differs from `lib/sub/`
+
+| | `lib/cmp/standard.*` | `lib/sub/*.lib` / `*.sub` |
+|---|---|---|
+| Scope | Generic device models (8 files total) | Vendor-specific parts (~4 891 files) |
+| Format | UTF-16 LE; one `.MODEL` per model | UTF-8/UTF-16 mix; one `.SUBCKT` per part |
+| Referenced via | `Value <model>` on a primitive | `.lib <file>` + `X<inst> nets <subckt>` |
+| Lookup | `ComponentModelCatalog.find()` | `parse_subckt(file)` (parser TBD) |
+
+For board-level simulation you'll mostly use `.lib` / `.include` of
+specific vendor parts. The `cmp` catalogue is for textbook circuits
+and quick discrete-component sketches.

--- a/ltspice/base/reference/log_channel_limits.md
+++ b/ltspice/base/reference/log_channel_limits.md
@@ -1,0 +1,81 @@
+# What `.log` does and doesn't capture
+
+LTspice has **one** observable file channel for run-time errors: the
+per-deck `<deck>.log` written next to the `.net` after a `-b` batch
+run. There is no GUI session journal, no event log, no AppData
+activity record. This is fundamentally different from solvers like
+Flotherm that write a continuous `LogFiles\logFile<timestamp>.xml`
+capturing every GUI action and popup.
+
+## What `.log` captures (i.e. what GUI's "SPICE Error Log" window shows)
+
+These are the errors that the solver itself emits during simulation,
+all of which appear in the `.log`:
+
+- **Solver convergence**: `Time step too small`, `Singular matrix`,
+  `Iteration limit reached`, gmin/source-stepping failures.
+- **Netlist syntax**: `Unknown subckt: XYZ`, `Could not find: V(out)`,
+  `Bad expression`, duplicate node names.
+- **Model loading**: `Could not open: foo.lib`, missing `.MODEL` cards,
+  encrypted-model decryption failures.
+- **Measurement**: `.MEAS` results (the structured outputs we parse),
+  `.MEAS` failures (`measurement failed`, `peakmag did not evaluate`).
+- **Initial conditions**: `.IC` / `.NODESET` warnings.
+- **Run summary**: total elapsed time, solver method, matrix stats.
+
+`sim_ltspice.log.parse_log` surfaces these as
+`LogResult.measures` / `.errors` / `.warnings`.
+
+## What `.log` does NOT capture
+
+These are GUI-side events that never touch the file system:
+
+- **Schematic-load failures**: `Symbol not found in library` when
+  opening an `.asc` interactively. The popup is shown; nothing is
+  logged.
+- **File-version warnings**: "This schematic was saved by a newer
+  version of LTspice…" — modal dialog, no log entry.
+- **Editing dialogs**: "Are you sure you want to discard…", "Place
+  Component" errors, ParseErrors during symbol editing.
+- **Updater popups**: from `updater.exe`, totally separate from
+  `LTspice.exe`.
+- **`-netlist` failure** (LTspice 26.0.1 regression): when
+  `LTspice.exe -netlist <file.asc>` hangs, **no log is written, no
+  exit code, no signal**. The process just sits at 0% CPU.
+
+## Practical implication
+
+The `sim_ltspice.runner` health-check has to use **two strategies**:
+
+| Failure mode | Detection |
+|---|---|
+| Solver error during a batch run | Parse `.log` → `LogResult.errors` |
+| LTspice never produces output (GUI hang, `-netlist` regression, session-0 hang) | Subprocess timeout (default 300 s in `sim_ltspice.runner`) → exit code 124 |
+| Schematic editing / interactive popup | Out of scope for batch driver; use UIA if needed |
+
+`run_net` already handles the first two automatically. There is no
+file-channel equivalent of "tail this log to monitor everything LTspice
+is doing."
+
+## If you want a popup-equivalent observability channel
+
+The closest thing LTspice has: the GUI's `View → SPICE Error Log` is a
+non-modal child window. Its content is written incrementally to
+`<deck>.log` as the solver runs, so tailing the file *during* a long
+batch run gives you live progress. There's no equivalent for events
+*before* the batch starts (schematic-parse stage) or for any GUI-only
+dialog.
+
+## Why this matters for agents
+
+When debugging "LTspice didn't produce output," the diagnostic order is:
+
+1. Did `<deck>.log` get written? If no → process never reached the
+   simulator (likely `-netlist` hang on 26.0.1, or session-0 hang).
+2. If yes, does `LogResult.errors` contain anything? If yes → solver
+   error; read the message.
+3. If `.log` has content but no errors and no `.raw` exists → the
+   netlist was missing an analysis directive (`.tran`, `.ac`, etc.).
+   `sim lint` catches this.
+
+`sim_ltspice` already implements this triage. Don't roll your own.

--- a/ltspice/base/reference/platform_dispatch.md
+++ b/ltspice/base/reference/platform_dispatch.md
@@ -1,25 +1,52 @@
-# Platform dispatch — when to use `--host <win1>`
+# Platform dispatch — when to run remotely on Windows
 
-LTspice has two very different install flavors. Pick the right one for
-what you're doing.
+LTspice has two install flavors with non-trivial capability gaps. Pick
+the right one for what you're doing.
+
+The placeholder `<windows-host>` below stands for whatever Windows
+machine is running `sim serve`. Configure it once via
+`~/.sim/config.toml`:
+
+```toml
+[server]
+host = "<windows-host>"   # an IP, a hostname, or a Tailscale name
+```
+
+…then `sim run …` routes there automatically with no `--host` flag.
+Or pass `--host <windows-host>` per invocation, or set `SIM_HOST`.
 
 ## macOS native (LTspice 17.x)
 
-- ✅ `.net` / `.cir` / `.sp` batch runs — fully supported
-- ✅ `.meas` result extraction — fully supported
-- 🟡 `.asc` input — only when schematic is flat + uses shipped library
-  symbols (sim-ltspice's native asc2net handles these)
+- ✅ `.net` / `.cir` / `.sp` batch runs — fully supported.
+- ✅ `.meas` result extraction — fully supported.
+- 🟡 `.asc` input — only when the schematic is flat + uses
+  shipped-library symbols (`sim-ltspice`'s native `asc2net` flattener
+  handles these without invoking LTspice).
 - ❌ Hierarchical `.asc`, custom `.subckt` symbols, `-ascii` raw
-  output, `-netlist` schematic→netlist conversion
+  output, `-netlist` schematic→netlist conversion.
 
-If `sim run my.asc --solver ltspice` raises `MacOSCannotFlatten`, your
-schematic is hitting one of the ❌ cases above. Route via win1.
+If `sim run my.asc --solver ltspice` raises `MacOSCannotFlatten`,
+your schematic is hitting one of the ❌ cases above. Route via a
+Windows host.
+
+## macOS native (LTspice 26.x)
+
+LTspice 26.0.0 was the first parallel macOS+Windows release (Dec 2025).
+Capability parity with Windows is greater than 17.x, but the same
+flat-asc-only constraint **applies in `sim-ltspice`'s flattener**
+because the library deliberately doesn't shell out to LTspice for
+authoring (the Python flattener handles flat + library-local
+schematics without touching LTspice). For hierarchical or
+custom-symbol `.asc` the answer is still: route via a Windows host.
 
 ## Windows (LTspice 26.x)
 
-- ✅ Everything. `.asc` input with any topology, `-netlist` pass,
-  `-ascii` raw output, full batch surface.
-- Reach it via `sim --host 100.90.110.79` (tailscale IP; see
+- ✅ Everything. `.asc` input with any topology, `-ascii` raw output,
+  full batch surface.
+- ⚠️ `-netlist` is **broken on 26.0.1** — see
+  [`command_line_switches.md`](command_line_switches.md) "Known
+  regressions". Use the in-process flattener instead.
+- Reach it via `sim --host <windows-host>` (configurable; see
   `../sim-cli/SKILL.md` for the HTTP dispatch model).
 
 ## Decision tree
@@ -28,33 +55,36 @@ schematic is hitting one of the ❌ cases above. Route via win1.
 .net input?  ────────────────→ Run local. macOS and Windows both fine.
 
 .asc input + flat + library-only? ──→ Run local on Mac (native asc2net).
-                                      Or on Win1 (uses LTspice -netlist).
+                                      Or on a Windows host.
 
-.asc input + hierarchy / custom lib? ──→ Route via sim --host 100.90.110.79.
+.asc input + hierarchy / custom lib? ──→ Route via sim --host <windows-host>.
 
-Need .raw in ASCII format? ──→ Win1 only (`-ascii` flag unsupported on Mac).
+Need .raw in ASCII format? ──→ Windows only (`-ascii` flag).
 
 Need schematic→netlist conversion WITHOUT simulating?
-                               ──→ Win1 only (`-netlist` is the command).
+                               ──→ Use sim_ltspice.schematic_to_netlist
+                                   (the broken `-netlist` flag is no
+                                   longer the recommended path).
 ```
 
 ## One command covers both
 
 ```bash
-# Auto-detect: local if possible, remote win1 otherwise.
+# Auto-detect: local if possible, remote Windows host otherwise.
 # sim-cli handles the routing based on the input's requirements.
-sim --host 100.90.110.79 run design.asc --solver ltspice
-```
+sim run design.asc --solver ltspice
 
-You can always use `--host 100.90.110.79` even for cases that would
-work locally — it's the universal answer. Costs a round-trip; gains
-feature parity.
+# Force-remote (always go to Windows even when local would work)
+sim --host <windows-host> run design.asc --solver ltspice
+```
 
 ## Why the difference?
 
-LTspice's macOS native build is a direct port with a minimal command
-surface (`-b` only). The full CLI — rotation of `-b` / `-Run` / `-netlist`
-/ `-ascii` / `-FastAccess` / `-encrypt` / `-sync` — only exists on
-Windows and in wine. This isn't a bug; Analog Devices explicitly
-scoped the Mac native build as "batch-run-a-netlist and nothing
-else." For full scripting, wine on macOS or a Windows host is the path.
+LTspice's macOS 17 native build was a direct port with a minimal
+command surface (`-b` only). The full CLI — `-b` / `-Run` / `-netlist`
+/ `-ascii` / `-FastAccess` / `-encrypt` / `-sync` — only existed on
+Windows and in wine. LTspice 26 narrowed the gap considerably (macOS
+26 supports more flags), but `sim-ltspice`'s default routing rules
+still favor the flatten-locally / solve-on-Windows split for
+hierarchical `.asc` because the Python flattener is the most reliable
+authoring path on either platform.

--- a/ltspice/base/reference/search_path_resolution.md
+++ b/ltspice/base/reference/search_path_resolution.md
@@ -1,0 +1,96 @@
+# Symbol & include search path resolution
+
+When LTspice (or `sim-ltspice`) tries to resolve `<symbol>` references
+in a `.asc` or `.lib` / `.include` directives in a `.net`, it walks
+search paths in a deterministic order. Knowing this order is the
+fastest way to debug "symbol not found" / "library not found" errors.
+
+## Resolution order
+
+```
+1. -I<path> from CLI               # injected at invoke time, takes precedence
+2. Settings → Search Paths         # persisted in LTspice.ini
+3. <schematic-dir>/                # the directory containing the .asc being opened
+4. <user-data>/lib/sym/  (recursive)
+5. <user-data>/lib/sub/
+```
+
+`<user-data>` is:
+- Windows: `%LOCALAPPDATA%\LTspice\`
+- macOS: `~/Library/Application Support/LTspice/`
+
+`<install-root>/lib/` (under `Programs\ADI\LTspice\`) is **not** on
+the search path — the bundled `lib.zip` is unzipped to the user-data
+dir on first launch and re-extracted by `LTspice.exe -sync`.
+
+## sim-ltspice extensions
+
+`sim_ltspice.symbols.SymbolCatalog` honours an additional env var on
+top of the LTspice-native order:
+
+```
+$LTSPICE_SYM_PATH        # colon-separated (POSIX) or semicolon (Windows)
+```
+
+This lets you point a single environment at a project-local symbol
+dir without modifying `LTspice.ini`. Catalog discovery is:
+
+```
+$LTSPICE_SYM_PATH        ─→ first
+<platform default lib/sym>  ─→ fallback
+```
+
+## Common failure modes
+
+### "Could not find symbol: XYZ" in `.asc`
+
+Symbol resolution failed. Check, in order:
+
+1. **Typo?** `SymbolCatalog().find("XYZ")` returns `None` if the name
+   is wrong. Use `.names()` to fuzzy-match.
+2. **Wrong category?** Top-level `lib/sym/*.asy` (54 primitives:
+   `res`, `cap`, `ind`, `voltage`, `nmos`, `npn`, …) vs. nested
+   `lib/sym/PowerProducts/LT3045.asy` (2 755 part-specific symbols).
+   The lookup is recursive, so naming the symbol is enough — but if
+   two categories collide on a name, the first match wins.
+3. **Custom symbol not on path?** Drop the `.asy` next to your `.asc`,
+   or pass `-I<dir>` at invoke time, or set `$LTSPICE_SYM_PATH`.
+4. **Stale install?** `LTspice.exe -sync` re-extracts the bundled
+   `lib.zip` if the user-data dir was nuked.
+
+### "Could not open: foo.lib"
+
+Library resolution failed. Most common cause: relative path in a
+`.include` / `.lib` directive that resolves against the *netlist's*
+directory, not the cwd. Two fixes:
+
+- Use an absolute path: `.lib "C:\path\to\foo.lib"`
+- Use `<schematic-dir>/`-relative: `.lib "./vendor/foo.lib"` and
+  ensure the file sits next to the `.net`.
+
+## Symbol library shape (LTspice 26)
+
+`<user-data>/lib/sym/` holds **6 571 `.asy` symbols** organized as:
+
+| Subtree | Count | Purpose |
+|---|---:|---|
+| `lib/sym/` (top-level) | 54 | Generic primitives — `res`, `cap`, `ind`, `voltage`, `nmos`, `npn`, etc. |
+| `lib/sym/PowerProducts/` | 2 755 | Vendor switching regulators, LDOs, motor drivers |
+| `lib/sym/Contrib/` | 2 423 | Community-contributed symbols |
+| `lib/sym/OpAmps/` | 759 | Op-amp catalogue |
+| `lib/sym/SpecialFunctions/` | 196 | Behavioural blocks, controllers |
+| `lib/sym/Switches/` | 173 | Voltage/current-controlled switches |
+| `lib/sym/References/` | 76 | Voltage references |
+| `lib/sym/ADC/` | 60 | A/D converters |
+| `lib/sym/Comparators/` | 51 | Comparators |
+| `lib/sym/Misc/` | 41 | Miscellaneous |
+| `lib/sym/DAC/` | 39 | D/A converters |
+| `lib/sym/FilterProducts/` | 26 | Filter parts |
+| `lib/sym/Digital/` | 17 | Digital gates |
+| `lib/sym/Optos/` | 16 | Opto-isolators |
+| `lib/sym/CurrentMonitors/` | 2 | Current sense |
+| `lib/sym/Transceivers/` | 2 | Transceivers |
+
+`lib/sub/` ships **2 798 `.sub` files + 2 093 `.lib` files** —
+SPICE-text sub-circuit definitions for vendor parts, referenced via
+`.lib` / `.include` rather than as schematic symbols.


### PR DESCRIPTION
## Summary
- New `driver/base/reference/error_codes.md` — triage table for the four runtime error-code families seen on the latest release, with severity / message template / condition / suggested driver action. Read this when `ok=false` lands and you need to decide retry-vs-fatal.
- New `driver/base/reference/headless_bootstrap_investigation.md` — closed/open question map: the overlay-onto-solved-scaffold approach is dead (translator crashed with `STATUS_STACK_BUFFER_OVERRUN`); next experiment is GUI bootstrap. Library-load command narrowed — 9 syntactic forms ruled out, recording oracle still required.
- `known_issues.md` — adds **ISSUE-006** (library-load command rejected regardless of form) with workaround (build attributes by hand) and resolution path.
- `base/reference/scripting.md` — pointer to the full **620-command** scripting catalogue in `sim-proj/dev-docs/`, plus an *unverified-pointer* section on script-chaining (third-party-reported via a public automation issue tracker; flagged as needing a local probe before relying on it).
- `SKILL.md` — surfaces the two new reference pages in the `base/` table.

Propagates the knowledge captured in [sim-proj#52](https://github.com/svd-ai-lab/sim-proj/pull/52) (which only updated `dev-docs/`) into the agent-facing skill.

## Test plan
- [x] Render the new markdown locally; verify cross-links resolve.
- [x] Read \`SKILL.md\` end-to-end as if a fresh agent — does the `base/` table give a clear "where do I look when X fails" path?
- [x] **Verify the script-chaining pointer** — VERIFIED 2026-04-27 via 3-probe sequence on a Windows test host against the latest release. Doc updated to reflect verified status.
- [x] Confirm ISSUE-006 in `known_issues.md` reads coherently next to ISSUE-001 / ISSUE-005 (similar shape — schema-valid, runtime-rejected).

Refs: sim-proj#51, sim-proj#52
