### PR TITLE
docs: align sim-skills with plugin split

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ contract every driver skill depends on).
 | Kind of content | Location | Audience |
 |---|---|---|
 | Shared runtime contract (lifecycle, commands, version probe, acceptance, escalation, input classification) | [`sim-cli/`](sim-cli/SKILL.md) + `sim-cli/reference/*.md` | End users' agents |
-| Solver-specific protocol (physics, APIs, quirks per version) | `<solver>/SKILL.md` + `<solver>/{reference,workflows,snippets}/` | End users' agents |
+| Solver-specific protocol (physics, APIs, quirks per version) | `<solver>/SKILL.md` in this repo for shared/public skills, or the matching `sim-plugin-<name>` repo for plugin-owned skills | End users' agents |
 | Runtime-injected tool skills (actuation objects sim-cli puts into `sim exec` — `gui`, future `fs` / `shell` / etc.) | [`sim-cli/<tool>/SKILL.md`](sim-cli/) | End users' agents |
 | Human-facing overview, skill grid, news | [`README.md`](README.md) | Humans browsing GitHub |
 | Contributor guide (this file) | `CLAUDE.md` | You, right now |
@@ -74,30 +74,34 @@ API itself is not repeated per solver.
    [`sim-cli/`](sim-cli/SKILL.md) instead of the per-driver SKILL.md.
 4. Update the `## File index` section of the SKILL.md if you add or
    rename files.
-5. Drift between the skill and the driver in
-   `../sim-cli/src/sim/drivers/<solver>/` is a bug. Fix one or the
-   other; don't leave them disagreeing.
+5. Drift between a skill and its driver plugin is a bug. Fix one or the
+   other; don't leave them disagreeing. For extracted drivers, the
+   plugin repo is the source of truth for driver-specific skills.
 
 ## When adding a new solver skill
 
 1. Create `<new-solver>/SKILL.md` with proper frontmatter.
 2. Start by pointing to `../sim-cli/SKILL.md` — the shared contract
    is not repeated. Keep your SKILL.md focused on the solver overlay.
-3. Mirror the section structure of an existing pilot
-   ([`fluent/SKILL.md`](fluent/SKILL.md),
-   [`matlab/SKILL.md`](matlab/SKILL.md),
-   [`comsol/SKILL.md`](comsol/SKILL.md)): Identity → Scope → Hard
+3. Mirror the section structure of an existing tracked skill such as
+   [`openfoam/SKILL.md`](openfoam/SKILL.md),
+   [`ltspice/SKILL.md`](ltspice/SKILL.md), or
+   [`coolprop/SKILL.md`](coolprop/SKILL.md): Identity → Scope → Hard
    constraints → Required protocol → Input validation → File index.
-4. Add the matching driver under
-   `../sim-cli/src/sim/drivers/<new-solver>/` and register it in
-   `../sim-cli/src/sim/drivers/__init__.py`.
-5. Add a row to the skill grid in [`README.md`](README.md). (The
-   grid lives in README, not here — contributors can link to it.)
+4. If the solver needs a runtime driver, create or update the matching
+   `sim-plugin-<name>` repository and register it through
+   [`sim-plugin-index`](https://github.com/svd-ai-lab/sim-plugin-index).
+   Do not add new driver code to this repo.
+5. Add a row to the skill grid in [`README.md`](README.md) only when
+   the skill folder is tracked in this repo. Plugin-owned skills should
+   be documented in their plugin repo and discoverable through the
+   plugin index.
 
 ## Runtime dependency
 
 These skills control the [`sim`](../sim-cli/) runtime. If you are
 developing locally, the runtime repo sits at `../sim-cli/`. See
-`../sim-cli/CLAUDE.md` for its internals (driver protocol, registry,
-HTTP endpoints). For each solver the matching driver lives at
-`../sim-cli/src/sim/drivers/<solver>/`.
+`../sim-cli/CLAUDE.md` for its internals (runtime protocol, plugin
+loading, HTTP endpoints). Solver drivers now live in individual
+`sim-plugin-<name>` repositories and are discoverable through the
+plugin index.

--- a/README.md
+++ b/README.md
@@ -1,171 +1,153 @@
 <div align="center">
 
-<img src="assets/banner.svg" alt="sim-skills — teach your agent to drive every engineering tool" width="820">
+<img src="assets/banner.svg" alt="sim-skills - teach your agent to drive engineering tools" width="820">
 
 <br>
 
-**Teach your agent to drive every engineering tool.**
+**Teach your agent to drive engineering tools through sim.**
 
-*[`sim-cli`](https://github.com/svd-ai-lab/sim-cli) opens the door.*
-*`sim-skills` walks the agent through it.*
+*[`sim-runtime`](https://github.com/svd-ai-lab/sim-cli) provides the runtime.*
+*`sim-skills` provides the agent playbooks.*
 
 <p align="center">
-  <a href="#-the-skill-grid"><img src="https://img.shields.io/badge/Skills-growing_library-8b5cf6?style=for-the-badge" alt="Skills library"></a>
-  <a href="https://github.com/svd-ai-lab/sim-cli"><img src="https://img.shields.io/badge/Runtime-sim--cli-3b82f6?style=for-the-badge" alt="sim-cli runtime"></a>
-  <a href="#-how-an-agent-uses-a-skill"><img src="https://img.shields.io/badge/Format-Anthropic_Skill-22c55e?style=for-the-badge" alt="Anthropic skill format"></a>
+  <a href="#-current-skills"><img src="https://img.shields.io/badge/Skills-lean_core-8b5cf6?style=for-the-badge" alt="Skills library"></a>
+  <a href="https://github.com/svd-ai-lab/sim-plugin-index"><img src="https://img.shields.io/badge/Drivers-plugin_repos-3b82f6?style=for-the-badge" alt="Plugin repositories"></a>
+  <a href="#-how-this-repo-fits-the-plugin-model"><img src="https://img.shields.io/badge/Model-runtime_plus_plugins-22c55e?style=for-the-badge" alt="Runtime plus plugins"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-Apache_2.0-eab308?style=for-the-badge" alt="License"></a>
 </p>
 
-<p align="center">
-  <img src="https://img.shields.io/badge/category-agent_playbooks-blueviolet" alt="Category">
-  <img src="https://img.shields.io/badge/one_folder-per_solver-cbd5e1" alt="One folder per solver">
-  <img src="https://img.shields.io/badge/pairs_with-sim--cli-3776AB" alt="Pairs with sim-cli">
-  <img src="https://img.shields.io/badge/status-alpha-f97316" alt="Status: alpha">
-</p>
-
-[The Skill Grid](#-the-skill-grid) · [Why](#-why-sim-skills) · [How to use](#-how-an-agent-uses-a-skill) · [Conventions](#-cross-skill-conventions) · [Runtime](#-runtime-dependency) · [sim-cli →](https://github.com/svd-ai-lab/sim-cli)
+[Current Skills](#-current-skills) . [Plugin Model](#-how-this-repo-fits-the-plugin-model) . [How Agents Use Skills](#-how-an-agent-uses-a-skill) . [Conventions](#-cross-skill-conventions) . [Runtime](#-runtime-dependency)
 
 </div>
 
 ---
 
-## 🤔 Why sim-skills?
+## Why sim-skills?
 
-LLM agents already know how to write PyFluent, MATLAB, COMSOL, and OpenFOAM scripts — training data is full of them. What they *don't* have is **operational discipline** for each tool: which inputs are physical decisions vs. operational defaults, what the acceptance criterion actually is, when to stop and ask, which API version's quirks bite where.
+LLM agents can often write solver scripts, but they still need operational discipline: which inputs are physical decisions, what counts as acceptance, when to inspect runtime state, when to stop, and which logs or artifacts prove the run actually worked.
 
-Writing the same discipline into every agent prompt from scratch is how teams burn weeks and waste compute. `sim-skills` is the missing library:
+`sim-skills` is the shared playbook layer for that discipline. It is intentionally smaller now that solver drivers have moved into individual plugin repositories.
 
-- **One folder per solver.** Each folder is a self-contained Anthropic-format skill — `SKILL.md` with YAML frontmatter, plus `reference/`, `workflows/`, `snippets/`, `tests/` as the SKILL.md points to them.
-- **Runtime control, not API tutoring.** The skills tell the agent how to drive `sim connect / exec / inspect / disconnect` safely — they assume the agent already knows the solver's own API, and teach it the *operational* layer around that.
-- **Cross-skill conventions baked in.** Input classification (Category A/B/C), acceptance-criterion rules, and escalation triggers live in [`CLAUDE.md`](CLAUDE.md) so every skill obeys the same protocol.
-- **Paired with [`sim-cli`](https://github.com/svd-ai-lab/sim-cli).** The runtime provides the transport; the skills provide the playbook. Neither works well alone.
-
-> Think of it this way: `sim-cli` is the ignition and the steering wheel. `sim-skills` is the driving school.
+- **Core agent protocols live here.** The shared `sim-cli` skill owns lifecycle, command surface, version probing, input classification, acceptance, and escalation.
+- **Open-source skills can live here.** Lightweight solver or library skills that do not require private/vendor assets may remain in this repo.
+- **Driver implementations live in plugins.** Runtime driver code ships through out-of-tree plugin packages and the plugin index.
+- **Plugin-specific skills travel with plugins.** When a driver needs specialized workflows, private references, GUI automation, or vendor-specific troubleshooting, keep that skill content with the matching plugin repo.
 
 ---
 
-## 🧭 The Skill Grid
+## How this repo fits the plugin model
 
-Every skill lives in its own top-level folder. The grid is **open and growing** — add a new skill by dropping a `<solver>/SKILL.md` in and registering it in [`CLAUDE.md`](CLAUDE.md). Current contents of `main`:
+The sim ecosystem is split deliberately:
 
-| Skill | Domain | Execution model | Phase | What it's for |
+| Layer | Repo | Audience | Contents |
+|---|---|---|---|
+| Runtime | [`sim-cli`](https://github.com/svd-ai-lab/sim-cli) | Users and plugin authors | `sim-runtime`, CLI commands, HTTP protocol, plugin loading |
+| Plugin registry | [`sim-plugin-index`](https://github.com/svd-ai-lab/sim-plugin-index) | Users and installers | Curated plugin metadata for `sim plugin list / install` |
+| Plugin repos | `sim-plugin-<name>` | Driver maintainers | Driver code, tests, packaged plugin metadata, plugin-owned skills |
+| Shared skills | This repo | Agents and contributors | Shared runtime skill plus open/public agent playbooks |
+
+This repo should not mirror every plugin. If a driver has been extracted to a plugin repository, keep the implementation and driver-specific agent playbook there. Link to the plugin registry from here instead of carrying stale copies.
+
+---
+
+## Current skills
+
+Current tracked skill folders on `main`:
+
+| Skill | Domain | Execution model | Status | Notes |
 |---|---|---|---|---|
-| [**sim-cli**](sim-cli/SKILL.md) | *Shared contract* | Both (persistent + one-shot) | Working ✅ | The runtime contract every driver skill depends on — session lifecycle, command surface, input classification, Step-0 version probe, acceptance, escalation. **Load alongside any driver skill below.** |
-| [**openfoam-sim**](openfoam/SKILL.md) | CFD (OSS) | Remote `sim serve` on Linux via SSH tunnel | Working ✅ | Meshing, MPI parallel, classifier-based pass/fail on OpenFOAM v2206 |
-| [**pybamm-sim**](pybamm/SKILL.md) | Battery modeling | One-shot `sim run --solver pybamm` | Working ✅ | PyBaMM DFN / SPM / SPMe battery models; no separate solver binary — the pybamm package version *is* the solver version. |
-| [**calculix-sim**](calculix/SKILL.md) | Static / frequency / thermal FEA | One-shot `ccx -i <file>` | Working ✅ | Open-source Abaqus-dialect `.inp` on Linux. Cantilever tip U2 = −2002 (0.1 % err). |
-| [**gmsh-sim**](gmsh/SKILL.md) | Mesh generation | One-shot `gmsh -3 <file.geo>` / Python API | Working ✅ | 2D/3D meshing with CAD import; exports for CalculiX/OpenFOAM/FEniCS/SU2. |
-| [**su2-sim**](su2/SKILL.md) | Open-source CFD | One-shot `SU2_CFD <file.cfg>` | Working ✅ | NACA0012 inviscid, RMS[Rho] dropped 3.5 orders. |
-| [**lammps-sim**](lammps/SKILL.md) | Molecular dynamics | One-shot `lmp -in <file.in>` | Working ✅ | LJ NVT Nose-Hoover, final T = 1.07 (target 1.5). |
-| [**scikit-fem-sim**](scikit_fem/SKILL.md) | Pure-Python FEM | One-shot Python script | Working ✅ | Poisson on unit square, u_max = 0.07345 (0.3 % err). |
-| [**elmer-sim**](elmer/SKILL.md) | Multi-physics FEM | One-shot `ElmerSolver <file.sif>` | Working ✅ | CSC-IT `.sif` heat/elasticity/EM/fluid. Steady heat max = 0.07426 (0.8 % err). |
-| [**meshio-sim**](meshio/SKILL.md) | Mesh format conversion | One-shot Python script | Working ✅ | 20+ mesh formats, the glue between sim's pre-processors and solvers. |
-| [**pyvista-sim**](pyvista/SKILL.md) | Post-processing | One-shot Python script | Working ✅ | Scalar stats, iso-surfaces, area/volume integration, headless PNG. |
-| [**pymfem-sim**](pymfem/SKILL.md) | High-order FEM | One-shot Python script | Working ✅ | LLNL MFEM bindings. Poisson u_max = 0.07353 (0.2 % err via UMFPackSolver). |
-| [**openseespy-sim**](openseespy/SKILL.md) | Structural / earthquake FEM | One-shot Python script | Working ✅ | PEER's OpenSees. Cantilever tip err 1.3e-12. |
-| [**sfepy-sim**](sfepy/SKILL.md) | Pure-Python FEM (weak forms) | One-shot Python script | Working ✅ | Term / Problem API. Poisson 1.3 % err on 8×8 mesh. |
-| [**openmdao-sim**](openmdao/SKILL.md) | Multi-disciplinary optimization | One-shot Python script | Working ✅ | NASA MDAO. Sellar coupled MDA y1 = 25.59, y2 = 12.06. |
-| [**fipy-sim**](fipy/SKILL.md) | Finite-volume PDE | One-shot Python script | Working ✅ | NIST FVM. 1D steady Poisson err 1.6e-15. |
-| [**pymoo-sim**](pymoo/SKILL.md) | Multi-objective optimization | One-shot Python script | Working ✅ | NSGA-II/III, MOEA/D, CMAES. ZDT1 36 Pareto solutions. |
-| [**pyomo-sim**](pyomo/SKILL.md) | Optimization modeling | One-shot Python script | Working ✅ | Sandia LP/MIP/NLP. Classic LP obj = 36 via HiGHS. |
-| [**simpy-sim**](simpy/SKILL.md) | Discrete-event simulation | One-shot Python script | Working ✅ | Queueing, manufacturing. M/M/1 L err 1.9 %. |
-| [**trimesh-sim**](trimesh/SKILL.md) | Triangular-mesh processing | One-shot Python script | Working ✅ | STL/OBJ/PLY, volume/area/inertia. Box V = 24 exact. |
-| [**devito-sim**](devito/SKILL.md) | Symbolic FD + JIT C codegen | One-shot Python script | Working ✅ | Imperial College. 2D heat mass conservation 4e-7. |
-| [**coolprop-sim**](coolprop/SKILL.md) | Thermo-properties | One-shot Python script | Working ✅ | REFPROP-equivalent. Water @ 1 atm T_sat = 373.124 K. |
-| [**scikit-rf-sim**](scikit_rf/SKILL.md) | RF / microwave analysis | One-shot Python script | Working ✅ | Touchstone I/O, S-parameters. Short/open/match S11 = −1/+1/0 exact. |
-| [**pandapower-sim**](pandapower/SKILL.md) | Power-system analysis | One-shot Python script | Working ✅ | Fraunhofer IEE. 2-bus PF vm_pu = 0.998, losses 1.4 kW. |
-| [**paraview-sim**](paraview/SKILL.md) | Post-processing / visualization | One-shot `pvpython` / `pvbatch` | Working ✅ | Kitware ParaView. 30+ file formats, Clip/Slice/Contour/StreamTracer, headless PNG rendering. |
-| [**isaac-sim**](isaac/SKILL.md) | Embodied-AI simulation | One-shot `sim run <script.py> --solver isaac` | Working ✅ | NVIDIA Isaac Sim 4.5 (Omniverse Kit). SimulationApp bootstrap contract, AST lint for import-order, `official_hello_world` + Franka + Replicator + warehouse_sdg snippets. |
-| [**newton-sim**](newton/SKILL.md) | GPU physics / embodied AI | Two routes: Route A (recipe JSON) or Route B (`.py` run-script) | Working ✅ | NVIDIA Newton 1.x on Warp. Declarative recipe schema, 6 solver backends (XPBD/VBD/MuJoCo/MPM/Style3D/SemiImplicit), basic_pendulum + robot_g1 + cable_twist E2E workflows. |
-| **+ your skill** | — | — | 🛠 | Drop a `<solver>/SKILL.md`, register in `CLAUDE.md`, open a PR |
+| [**sim-cli**](sim-cli/SKILL.md) | Shared runtime contract | Persistent sessions and one-shot runs | Core | Load alongside any solver or plugin skill. Owns lifecycle, command surface, Step-0 version probe, input classification, acceptance, and escalation. |
+| [**sim-cli/gui**](sim-cli/gui/SKILL.md) | Runtime-injected GUI tool | GUI-capable sessions | Core | Shared actuation API for drivers that expose a `gui` object through `sim exec`. |
+| [**openfoam-sim**](openfoam/SKILL.md) | Open-source CFD | Case files, command-line runs, remote Linux workflows | Active | OpenFOAM case setup, solver selection, mesh/log diagnosis, parallel execution, and post-processing guidance. |
+| [**ltspice-sim**](ltspice/SKILL.md) | Circuit simulation | One-shot batch runs | Active | Netlist authoring, platform dispatch, `.meas` result extraction, and log-based acceptance. |
+| [**coolprop-sim**](coolprop/SKILL.md) | Thermophysical properties | One-shot Python scripts | Active | Property lookups for fluids, humid air, saturation curves, and cycle-analysis tasks. |
 
-**Legend** · ✅ Working · 🟡 In progress (phased rollout) · 🛠 Open for contribution
-
----
-
-## 🎯 How an agent uses a skill
-
-When a task involves a supported solver, the agent follows the same five steps for every skill:
-
-1. **Identify the solver** from the user's request
-2. **Read** `<solver>/SKILL.md` — its YAML `description` says exactly when the skill applies, and the body has the required protocol
-3. **Follow the protocol**: input validation → connect → execute → verify → report
-4. **Reach for supporting files** when SKILL.md tells it to:
-   - `reference/` — patterns, templates, API docs
-   - `workflows/` — end-to-end example cases
-   - `snippets/` — ready-made `sim exec` payloads
-   - `skill_tests/` — manual acceptance test cases
-5. **Never invent solver-specific defaults** for Category A inputs (physical decisions) — ask the user
-
-The human workflow is even simpler: an engineer points the LLM at `sim-skills`, names the solver, and the agent knows what to do next.
-
----
-
-## 📏 Cross-skill conventions
-
-These apply to every driver skill in the grid. They live canonically in
-the **[`sim-cli/`](sim-cli/SKILL.md)** shared skill — summary here:
-
-| Convention | One-line rule | Full |
-|---|---|---|
-| **Category A inputs** | Physical decisions (geometry, materials, BCs, acceptance criteria). **Ask the user** if absent. | [input_classification.md](sim-cli/reference/input_classification.md) |
-| **Category B inputs** | Operational defaults (processors, ui_mode, smoke-test iterations). May default; must disclose. | [input_classification.md](sim-cli/reference/input_classification.md) |
-| **Category C inputs** | File-derivable (cell zones, surface names). Infer via a diagnostic snippet, not from reference examples. | [input_classification.md](sim-cli/reference/input_classification.md) |
-| **Acceptance criteria** | `exit_code == 0` is **not** sufficient. Every task needs an outcome-based criterion. | [acceptance.md](sim-cli/reference/acceptance.md) |
-| **Step-0 version probe** | Mandatory. `sim inspect session.versions` after connect; pick layered-folder content from the returned profile. | [version_awareness.md](sim-cli/reference/version_awareness.md) |
-| **Reference examples ≠ defaults** | Values in `<skill>/reference/examples/` describe a specific published test case. Offer them, never silently adopt them. | [input_classification.md](sim-cli/reference/input_classification.md) |
-| **When to stop** | Solver fails to launch, snippet raises or returns `ok=false`, session drifts, acceptance fails → report, don't silently retry. | [escalation.md](sim-cli/reference/escalation.md) |
-
----
-
-## 🔌 Runtime dependency
-
-These skills are useless without the [`sim-cli`](https://github.com/svd-ai-lab/sim-cli) runtime. The runtime provides:
-
-- `sim connect / exec / inspect / disconnect` for persistent solver sessions
-- `sim run` for one-shot scripts
-- `sim lint`, `sim logs`, `sim ps` for the operational layer around both
-
-For each solver there is a matching driver, distributed as an out-of-tree plugin package: [`sim-plugin-<solver>`](https://github.com/svd-ai-lab/sim-plugin-index) (browse via `sim plugin list` after installing `sim-runtime`). The skill in this repo is the agent-facing protocol; the plugin is the Python-facing implementation. Neither works well alone.
+Extracted or private drivers are intentionally not listed as local folders here. Discover installable drivers through:
 
 ```bash
-# 1. Install the runtime (solver-agnostic core):
+uv pip install sim-runtime
+sim plugin list
+sim plugin install <name>
+```
+
+---
+
+## How an agent uses a skill
+
+When a task involves sim, the agent should:
+
+1. Read [`sim-cli/SKILL.md`](sim-cli/SKILL.md) for the runtime contract.
+2. Read the solver or plugin-specific `SKILL.md`.
+3. Run the required Step-0 probe before choosing version-specific guidance.
+4. Classify missing inputs before inventing defaults.
+5. Execute through `sim connect`, `sim exec`, `sim inspect`, `sim run`, and related runtime commands as appropriate.
+6. Verify outcome-based acceptance, not just `exit_code == 0`.
+
+For plugin-owned skills, the plugin repo is the source of truth. Do not recreate driver-specific instructions here unless they are genuinely shared across multiple drivers.
+
+---
+
+## Cross-skill conventions
+
+These apply to every driver skill, whether the skill lives here or inside a plugin repo. The canonical source is [`sim-cli/`](sim-cli/SKILL.md).
+
+| Convention | One-line rule | Full reference |
+|---|---|---|
+| **Category A inputs** | Physical decisions require the user or a task spec. | [input_classification.md](sim-cli/reference/input_classification.md) |
+| **Category B inputs** | Operational defaults may be chosen, but must be disclosed. | [input_classification.md](sim-cli/reference/input_classification.md) |
+| **Category C inputs** | File-derivable facts should be inferred from diagnostics. | [input_classification.md](sim-cli/reference/input_classification.md) |
+| **Acceptance criteria** | A successful process exit is not enough. | [acceptance.md](sim-cli/reference/acceptance.md) |
+| **Step-0 version probe** | Inspect runtime versions before loading version-specific guidance. | [version_awareness.md](sim-cli/reference/version_awareness.md) |
+| **Escalation** | Report launch failures, runtime drift, snippet failures, and failed acceptance directly. | [escalation.md](sim-cli/reference/escalation.md) |
+
+---
+
+## Runtime dependency
+
+These skills are designed for the [`sim-runtime`](https://github.com/svd-ai-lab/sim-cli) CLI and plugin system.
+
+```bash
+# Install the solver-agnostic runtime.
 uv pip install sim-runtime
 
-# 2. Install the plugin for the solver you want:
-sim plugin install <name>          # e.g. sim plugin install pybamm
+# Discover and install driver plugins.
+sim plugin list
+sim plugin install <name>
 
-# 3. Then point your LLM agent at this repo and let it read the SKILL.md files.
+# Then point your agent at the relevant SKILL.md files.
 ```
+
+The runtime provides transport and process control. Plugins provide driver implementations. Skills provide the agent-facing protocol for using both without drifting into ad hoc automation.
 
 ---
 
-## 📂 Repo layout
+## Repo layout
 
-```
+```text
 sim-skills/
-├── README.md          this file (human-facing)
-├── CLAUDE.md          AI-facing index, protocol, cross-skill conventions
+├── README.md          Human-facing overview
+├── CLAUDE.md          Contributor guide for editing this repo
 ├── LICENSE            Apache-2.0
-│
-├── openfoam/          OSS solver skill (one example among many)
-├── pybamm/            …
-├── …/                 one directory per skill — see "Skill Grid" above
-│
-└── assets/            banner and related graphics
+├── NOTICE
+├── assets/            Banner and related graphics
+├── sim-cli/           Shared runtime contract and runtime-injected tool skills
+├── openfoam/          OpenFOAM agent playbook
+├── ltspice/           LTspice agent playbook
+└── coolprop/          CoolProp agent playbook
 ```
 
-Each `<solver>/` directory is self-contained: `SKILL.md` at the top is the agent entry point; the rest (`reference/`, `workflows/`, `snippets/`, `tests/`, `skill_tests/`, `docs/`) is supporting material the SKILL.md links to as needed. Folder shapes vary by skill and by phase.
+Ignored local folders such as `.local/`, `.claude/`, or local vendor/reference caches are not part of the public skill grid.
 
 ---
 
-## 🔗 Related projects
+## Related projects
 
-- **[`sim-cli`](https://github.com/svd-ai-lab/sim-cli)** — the paired runtime. One CLI, one HTTP protocol, an open driver registry. This repo is its agent-facing twin.
-- **[`sim-plugin-index`](https://github.com/svd-ai-lab/sim-plugin-index)** — curated registry of out-of-tree solver plugins (`sim plugin list / install`).
+- **[`sim-cli`](https://github.com/svd-ai-lab/sim-cli)** - runtime, CLI, protocol, and plugin loading.
+- **[`sim-plugin-index`](https://github.com/svd-ai-lab/sim-plugin-index)** - curated registry for installable driver plugins.
+- **`sim-plugin-<name>` repos** - driver-specific implementations, tests, plugin metadata, and plugin-owned skills.
 
 ---
 
-## 📄 License
+## License
 
-Apache-2.0 — see [LICENSE](LICENSE). Individual skills may ship their own `LICENSE` file (all Apache-2.0 today).
+Apache-2.0 - see [LICENSE](LICENSE). Plugin repositories may carry their own notices and licensing constraints.


### PR DESCRIPTION
## Summary
- Rewrite the README around the current plugin-based split instead of the old all-skills-in-one-repo grid
- List only tracked local skill folders: sim-cli, sim-cli/gui, openfoam, ltspice, and coolprop
- Update contributor guidance in CLAUDE.md so extracted drivers and plugin-owned skills stay with their plugin repos

## Verification
- Checked README links to tracked local files
- Ran `git diff --check`
- Searched README/CLAUDE.md for stale removed-skill and old in-core driver-path references