### PR TITLE
[codex] Document generic driver options

### DIFF
--- a/sim-cli/reference/command_surface.md
+++ b/sim-cli/reference/command_surface.md
@@ -46,19 +46,23 @@ Starts the HTTP server. Usually launched once per host; `sim connect`
 on a local host auto-starts a server if none is running. Run manually
 for remote boxes.
 
-### `sim connect --solver <solver> [--mode MODE] [--ui-mode UI] [--processors N]`
+### `sim connect --solver <solver> [--mode MODE] [--ui-mode UI] [--processors N] [--workspace PATH] [--driver-option KEY=VALUE]...`
 
 Launches the solver inside the server and holds a session open.
-Solver-specific flags:
+Core launch flags:
 
 | Flag | Drivers that use it |
 |---|---|
 | `--mode <mode>` | drivers with multiple runtime modes |
-| `--ui-mode gui \| headless` | GUI-capable drivers |
+| `--ui-mode gui \| no_gui` | GUI-capable drivers |
 | `--processors N` | any MPI-capable solver |
+| `--workspace PATH` | drivers with a run/work directory concept |
+| `--driver-option KEY=VALUE` | generic plugin-owned launch option passthrough; repeat as needed |
 
-The driver skill documents which flags its driver accepts and what the
-defaults mean.
+`--driver-option` is intentionally opaque to sim-cli. The driver skill
+documents which keys its driver accepts, what the defaults mean, and how
+the plugin validates or translates them. Keep solver-specific launch
+settings here instead of inventing new top-level sim-cli flags.
 
 ### `sim exec [<code>] [--file PATH] [--label LABEL]`
 

--- a/sim-cli/reference/input_classification.md
+++ b/sim-cli/reference/input_classification.md
@@ -43,8 +43,11 @@ These affect runtime / performance / convenience only, not what the
 simulation physically represents:
 
 - `--processors N` (parallelism)
-- `--ui-mode gui | headless`
+- `--ui-mode gui | no_gui`
 - `--mode meshing | solver` when only one makes sense for the task
+- `--workspace PATH` (run directory / artifact location)
+- `--driver-option KEY=VALUE` when the driver skill classifies the key
+  as operational rather than physical
 - Smoke-test iteration counts (e.g. "run 10 iters to check setup")
 - Output verbosity, log locations
 

--- a/sim-cli/reference/lifecycle.md
+++ b/sim-cli/reference/lifecycle.md
@@ -17,15 +17,16 @@ CONNECT → STEP-0 VERSION PROBE → [STEP × N] → DISCONNECT
 ```
 
 - One session per task. Do not reuse a session across unrelated tasks.
-- Connect with the correct driver-specific flags (mode, ui-mode,
-  processors). Mode cannot change mid-session.
+- Connect with the correct core launch flags (`mode`, `ui-mode`,
+  `processors`, `workspace`) and any plugin-owned `--driver-option`
+  values documented by the driver skill. Mode cannot change mid-session.
 - Always disconnect explicitly, even if steps failed.
 
 ## Pattern 1 — Connect + verify
 
 **When**: at the start of every task.
 
-1. Run `sim connect --solver <solver> [driver-specific flags]`.
+1. Run `sim connect --solver <solver> [core launch flags] [--driver-option KEY=VALUE]...`.
 2. Check exit code = 0.
 3. Run `sim inspect session.summary`. Verify `connected=true`,
    `mode=<expected>`, `run_count=0`.


### PR DESCRIPTION
## Summary

Updates the generic sim-cli skill to match the public CLI driver option change:

- documents `--workspace` and repeated `--driver-option KEY=VALUE` on `sim connect`
- clarifies that `--driver-option` is opaque to sim-cli and validated by plugin/driver skills
- updates lifecycle guidance to use core launch flags plus plugin-owned driver options
- updates input classification so driver options are only operational when the driver skill says so

No solver-specific workflow or solver-specific option names are included.

## Validation

- Reviewed the diff for solver-specific wording; the new text is generic only.
