### PR TITLE
Add sim-cli tool choice reference

### DIFF
--- a/sim-cli/SKILL.md
+++ b/sim-cli/SKILL.md
@@ -81,6 +81,8 @@ its window-not-found troubleshooting.
 | [`reference/acceptance.md`](reference/acceptance.md) | At the end of every task — outcome-based evaluation. `exit_code == 0` alone is **not** acceptance. |
 | [`reference/escalation.md`](reference/escalation.md) | When something goes wrong — what to stop on, what to report. Do not silently retry. |
 
+When sim-cli is one valid path but not the only path, use [`reference/tool_choice.md`](reference/tool_choice.md) to choose between live `sim ...` commands and file-side Python/vendor-SDK recipes.
+
 ---
 
 ## Hard constraints (apply to every sim-cli session)

--- a/sim-cli/reference/acceptance.md
+++ b/sim-cli/reference/acceptance.md
@@ -72,6 +72,9 @@ After the final step (persistent) or the single `sim run` return
    ERROR lines.
 2. Extract the numeric value(s) the criterion needs — via
    `sim inspect last.result` or `parse_output(stdout)`.
+   The acceptance check itself can be a python computation against output
+   files, a sim inspect query against the live session, or a vendor-script
+   invoked via sim run — pick whichever is closest to where the data lives.
 3. Compare against the criterion. Record the comparison explicitly in
    the final report: "`T_max = 82.3 °C` — criterion `< 85 °C` ✅".
 4. If any criterion fails — task is **INCOMPLETE**. Report which

--- a/sim-cli/reference/tool_choice.md
+++ b/sim-cli/reference/tool_choice.md
@@ -1,0 +1,35 @@
+# Tool choice
+
+sim-cli is the right tool when the task needs a live solver session, vendor-only Python inside the solver, GUI actuation, runtime version probing, or Windows-friendly streaming diagnostics. For post-mortem artifact reads and small acceptance computations, prefer the file-side Python path when it is closer to the data.
+
+Keep both paths visible when both are valid. Pick the one that matches the state the user actually has.
+
+## Example 1: read an Abaqus `.sta` after a job
+
+| Mode | Pick when | Recipe |
+|---|---|---|
+| Live | The solve is in progress or an Abaqus session is already open. | `sim inspect job.diagnostics` |
+| Post-mortem | The job finished and `job.sta` is on disk. | `python -c "from pathlib import Path; print(Path('job.sta').read_text(errors='replace'))"` |
+
+## Example 2: read a Mechanical `.rst`
+
+| Mode | Pick when | Recipe |
+|---|---|---|
+| Live | Mechanical is open and you need to add/evaluate result objects in the Solution tree. | `sim exec` with IronPython, for example `sol.Children[0].Maximum.Value` |
+| Post-mortem | The solve already finished and you only need result data from the file. | Use `ansys-dpf-core` in normal CPython against the downloaded `.rst`. |
+
+```python
+from ansys.dpf import core as dpf
+
+ds = dpf.DataSources("file.rst")
+model = dpf.Model(ds)
+disp = model.results.displacement().eval()
+stress = model.results.stress().eval()
+```
+
+## Example 3: introspect a saved COMSOL `.mph`
+
+| Mode | Pick when | Recipe |
+|---|---|---|
+| Live | The model needs to be mutated, solved, or compared against the live JPype session. | `sim inspect comsol.model.describe_text` |
+| Post-mortem | The question is about a saved `.mph`: parameters, physics tags, solved/unsolved state, mesh size. | `from sim_plugin_comsol.lib import inspect_mph; inspect_mph(path)` |


### PR DESCRIPTION
## Summary
- Add `sim-cli/reference/tool_choice.md` with side-by-side live and post-mortem paths for Abaqus `.sta`, Mechanical `.rst`, and COMSOL `.mph` workflows.
- Cross-link the new reference from `sim-cli/SKILL.md`.
- Clarify that acceptance checks can run where the data lives: file-side Python, live `sim inspect`, or vendor scripts via `sim run`.

## Related
- Builds on svd-ai-lab/sim-proj#94.

## Validation
- `git diff --cached --check`
- `PYTHONUTF8=1 python C:\Users\jiwei\.codex\skills\.system\skill-creator\scripts\quick_validate.py sim-cli`