### PR TITLE
[codex] document python helper environment preference

### DIFF
--- a/sim-cli/SKILL.md
+++ b/sim-cli/SKILL.md
@@ -109,6 +109,17 @@ When sim-cli is one valid path but not the only path, use [`reference/tool_choic
    `.../examples/` directory describe a specific published test case.
    You may offer them as examples, but must wait for explicit
    confirmation before adopting them.
+6. **Prefer uv for file-side Python helpers when available.** `sim` is
+   a CLI and can be invoked directly when installed. Do not wrap `sim`
+   in `uv run` unless you are intentionally using a source checkout or
+   project-local environment. For ordinary host/file-side Python helpers
+   used across solvers — plotting with matplotlib, CSV/JSON parsing,
+   report generation, lightweight acceptance calculations — prefer
+   `uv run python ...` or `uv run --with <pkg> python ...` when uv is
+   available because it makes dependencies explicit. If uv is unavailable
+   or the user has provided a specific Python environment, use the user's
+   environment. Vendor-embedded Python paths remain solver-specific and
+   should be run through the driver skill's documented `sim` workflow.
 
 ---
 

--- a/sim-cli/reference/tool_choice.md
+++ b/sim-cli/reference/tool_choice.md
@@ -9,7 +9,7 @@ Keep both paths visible when both are valid. Pick the one that matches the state
 | Mode | Pick when | Recipe |
 |---|---|---|
 | Live | The solve is in progress or an Abaqus session is already open. | `sim inspect job.diagnostics` |
-| Post-mortem | The job finished and `job.sta` is on disk. | `python -c "from pathlib import Path; print(Path('job.sta').read_text(errors='replace'))"` |
+| Post-mortem | The job finished and `job.sta` is on disk. | Prefer `uv run python -c "from pathlib import Path; print(Path('job.sta').read_text(errors='replace'))"` when uv is available; otherwise use the user's Python environment. |
 
 ## Example 2: read a Mechanical `.rst`
 


### PR DESCRIPTION
## Summary
- Add shared sim-cli guidance for file-side Python helper scripts across solvers.
- Clarify that `sim` is an installed CLI and should not be wrapped in `uv run` unless intentionally using a source checkout or project-local environment.
- Prefer `uv run python ...` / `uv run --with <pkg> python ...` for plotting, CSV/JSON parsing, report generation, and lightweight acceptance calculations when uv is available.

## Validation
- `git diff --check`
- Checked the guidance text with `rg` to verify the intended wording.